### PR TITLE
Add neighbor-cache reuse, energy-only inference, and sparse matscipy neighbor lists for ASE-Torch

### DIFF
--- a/alphanet/config.py
+++ b/alphanet/config.py
@@ -8,7 +8,10 @@ from pydantic_settings import BaseSettings
 
 try:
     VERSION = (
-        subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+        subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
     )
 except Exception:
     VERSION = "NA"

--- a/alphanet/data.py
+++ b/alphanet/data.py
@@ -123,7 +123,7 @@ class CustomPickleDataset(InMemoryDataset):
 
     #def get_idx_split(self, data_size, train_size=None, valid_size=None, seed=None):
     def get_idx_split(self, data_size, train_size=None, valid_size=None, test_size=None, seed=None):
-      ids = shuffle(list(range(data_size)))
+      ids = shuffle(list(range(data_size)), random_state=seed)
       if train_size is not None and valid_size is None:
           train_idx = ids[:train_size]
           

--- a/alphanet/data.py
+++ b/alphanet/data.py
@@ -4,6 +4,7 @@ import numpy as np
 from tqdm import tqdm
 import torch
 from sklearn.utils import shuffle
+from sklearn.model_selection import train_test_split
 import joblib
 from torch_geometric.data import Data, DataLoader, InMemoryDataset, download_url, extract_zip
 
@@ -26,7 +27,7 @@ def get_pic_datasets(root, name, config):
             test_dataset = test_dataset[test_indices]
     else:
       
-        dataset = CustomPickleDataset(name=name, root=root)
+        dataset = CustomPickleDataset(name=name, root=root, config=config)
 
  
         split_idx = dataset.get_idx_split(len(dataset.data.y), train_size=config.train_size, valid_size=config.valid_size, test_size=config.test_size, seed=config.seed)
@@ -120,7 +121,8 @@ class CustomPickleDataset(InMemoryDataset):
         print('Saving...')
         torch.save((data, slices), self.processed_paths[0])
 
-    def get_idx_split(self, data_size, train_size=None, valid_size=None, seed=None):
+    #def get_idx_split(self, data_size, train_size=None, valid_size=None, seed=None):
+    def get_idx_split(self, data_size, train_size=None, valid_size=None, test_size=None, seed=None):
       ids = shuffle(list(range(data_size)))
       if train_size is not None and valid_size is None:
           train_idx = ids[:train_size]

--- a/alphanet/evaler.py
+++ b/alphanet/evaler.py
@@ -113,8 +113,8 @@ class Evaluator:
             mask = deviation < threshold
             preds_force_filtered = preds_force[mask]
             targets_force_filtered = targets_force[mask]
-            force_mae_filtered = 0.5*torch.mean(torch.abs(preds_force_filtered - targets_force_filtered)).item()
-            force_rmse_filtered = 0.5*torch.sqrt(torch.mean((preds_force_filtered - targets_force_filtered) ** 2)).item()
+            force_mae_filtered = torch.mean(torch.abs(preds_force_filtered - targets_force_filtered)).item()
+            force_rmse_filtered = torch.sqrt(torch.mean((preds_force_filtered - targets_force_filtered) ** 2)).item()
 
             plt.scatter(
                 targets_force_filtered.cpu().numpy(),

--- a/alphanet/infer/calc.py
+++ b/alphanet/infer/calc.py
@@ -85,7 +85,7 @@ class AlphaNetCalculator(Calculator):
             device=self.device
         )
         pos = torch.tensor(
-            calc_atoms.get_positions(), 
+            calc_atoms.get_positions(wrap=True), 
             dtype=self.precision, 
             device=self.device, 
             requires_grad=(self.config.compute_forces)  

--- a/alphanet/infer/calc.py
+++ b/alphanet/infer/calc.py
@@ -141,6 +141,7 @@ class AlphaNetCalculator(Calculator):
                 skin=self.skin,
                 max_num_neighbors_threshold=self.max_num_neighbors_threshold,
                 precision=self.precision,
+                numbers=numbers,
             )
             self._reference_positions = positions.copy()
             self._reference_cell = cell_array.copy()

--- a/alphanet/infer/calc.py
+++ b/alphanet/infer/calc.py
@@ -1,7 +1,7 @@
-import torch
 import numpy as np
+import torch
 from ase.calculators.calculator import Calculator, all_changes
-from ase.data import atomic_numbers
+from alphanet.models.graph import build_neighbor_topology, graph_from_neighbor_topology
 from alphanet.models.model import AlphaNetWrapper
 
 class AlphaNetCalculator(Calculator):
@@ -15,7 +15,17 @@ class AlphaNetCalculator(Calculator):
     """
     implemented_properties = ['energy', 'free_energy', 'forces', 'stress']
 
-    def __init__(self, ckpt_path, config, device='cpu', precision='32', **kwargs):
+    def __init__(
+        self,
+        ckpt_path,
+        config,
+        device='cpu',
+        precision='32',
+        reuse_neighbors=True,
+        skin=0.5,
+        max_num_neighbors_threshold=50,
+        **kwargs,
+    ):
         """
         Initializes the AlphaNetCalculator.
 
@@ -49,6 +59,97 @@ class AlphaNetCalculator(Calculator):
         self.model.eval() # Set model to evaluation mode
         self.model.to(self.device)
         self.config = config
+        self.reuse_neighbors = reuse_neighbors
+        self.supports_neighbor_cache = hasattr(self.model, "forward_graph")
+        self.skin = max(float(skin), 0.0)
+        self.max_num_neighbors_threshold = max_num_neighbors_threshold
+        self._neighbor_topology = None
+        self._reference_positions = None
+        self._reference_cell = None
+        self._reference_numbers = None
+        self._reference_pbc = None
+        self._neighbor_cache_stats = {"rebuilds": 0, "reuses": 0}
+
+    @property
+    def neighbor_cache_stats(self):
+        return dict(self._neighbor_cache_stats)
+
+    def reset_neighbor_cache(self):
+        self._neighbor_topology = None
+        self._reference_positions = None
+        self._reference_cell = None
+        self._reference_numbers = None
+        self._reference_pbc = None
+
+    def _prepare_atoms(self):
+        if not self.atoms.pbc.any():
+            print("Non-periodic system detected. Automatically adding a large vacuum box for calculation.")
+            calc_atoms = self.atoms.copy()
+            padding = 20.0
+            new_cell_dims = calc_atoms.get_positions().ptp(axis=0) + padding
+            calc_atoms.set_cell(np.diag(new_cell_dims))
+            calc_atoms.center()
+            calc_atoms.pbc = True
+            return calc_atoms
+        return self.atoms
+
+    def _max_displacement_since_rebuild(self, positions, cell, pbc):
+        if self._reference_positions is None or self._reference_cell is None:
+            return float("inf")
+        aligned_positions = self._align_positions_to_reference(positions, cell, pbc)
+        delta_cart = aligned_positions - self._reference_positions
+        distances = np.linalg.norm(delta_cart, axis=1)
+        return float(np.max(distances)) if distances.size else 0.0
+
+    def _align_positions_to_reference(self, positions, cell, pbc):
+        if (
+            self._reference_positions is None
+            or self._reference_cell is None
+            or not np.allclose(cell, self._reference_cell, atol=1e-12, rtol=0.0)
+        ):
+            return positions.copy()
+        inverse_cell = np.linalg.inv(cell)
+        current_frac = positions @ inverse_cell
+        reference_frac = self._reference_positions @ inverse_cell
+        delta_frac = current_frac - reference_frac
+        periodic_axes = np.asarray(pbc, dtype=bool)
+        delta_frac[:, periodic_axes] -= np.round(delta_frac[:, periodic_axes])
+        return (reference_frac + delta_frac) @ cell
+
+    def _should_rebuild_topology(self, positions, cell, numbers, pbc):
+        if not self.reuse_neighbors or self.skin <= 0.0:
+            return True
+        if self._neighbor_topology is None:
+            return True
+        if self._reference_numbers is None or numbers.shape != self._reference_numbers.shape:
+            return True
+        if not np.array_equal(numbers, self._reference_numbers):
+            return True
+        if self._reference_pbc is None or not np.array_equal(np.asarray(pbc, dtype=bool), self._reference_pbc):
+            return True
+        if self._reference_cell is None or not np.allclose(cell, self._reference_cell, atol=1e-12, rtol=0.0):
+            return True
+        return self._max_displacement_since_rebuild(positions, cell, pbc) > (0.5 * self.skin)
+
+    def _build_or_reuse_topology(self, positions, cell_array, numbers, pbc, pos, natoms):
+        if self._should_rebuild_topology(positions, cell_array, numbers, pbc):
+            self._neighbor_topology = build_neighbor_topology(
+                pos=pos.detach(),
+                natoms=natoms,
+                cell=torch.tensor(cell_array, dtype=self.precision, device=self.device).detach(),
+                cutoff=self.config.cutoff,
+                skin=self.skin,
+                max_num_neighbors_threshold=self.max_num_neighbors_threshold,
+                precision=self.precision,
+            )
+            self._reference_positions = positions.copy()
+            self._reference_cell = cell_array.copy()
+            self._reference_numbers = numbers.copy()
+            self._reference_pbc = np.asarray(pbc, dtype=bool).copy()
+            self._neighbor_cache_stats["rebuilds"] += 1
+        else:
+            self._neighbor_cache_stats["reuses"] += 1
+        return self._neighbor_topology
 
     def calculate(self, atoms=None, properties=None, system_changes=all_changes):
         """
@@ -61,43 +162,16 @@ class AlphaNetCalculator(Calculator):
         """
         Calculator.calculate(self, atoms, properties, system_changes)
         properties = properties or ['energy']
-        
-        # --- Handle Non-Periodic Systems ---
-        # If the system is not periodic (e.g., a molecule), we create a copy and
-        # place it in a large box with vacuum padding. This allows the model,
-        # which assumes periodicity, to treat it as an isolated system.
-        if not self.atoms.pbc.any():
-            print("Non-periodic system detected. Automatically adding a large vacuum box for calculation.")
-            calc_atoms = self.atoms.copy()
-            # Add 20 Å of vacuum padding around the molecule
-            padding = 20.0
-            new_cell_dims = calc_atoms.get_positions().ptp(axis=0) + padding
-            calc_atoms.set_cell(np.diag(new_cell_dims))
-            calc_atoms.center()
-            calc_atoms.pbc = True # Treat it as periodic now
-        else:
-            calc_atoms = self.atoms
+        calc_atoms = self._prepare_atoms()
+        needs_stress = 'stress' in properties
+        needs_forces = needs_stress or ('forces' in properties)
+        grad_enabled = needs_forces or needs_stress
 
         # --- Prepare Tensors for the Model ---
-        z = torch.tensor(
-            calc_atoms.get_atomic_numbers(), 
-            dtype=torch.long, 
-            device=self.device
-        )
-        pos = torch.tensor(
-            calc_atoms.get_positions(wrap=True), 
-            dtype=self.precision, 
-            device=self.device, 
-            requires_grad=(self.config.compute_forces)  
-        )
-       
-        # Cell should only be provided if the system is periodic
-        cell = torch.tensor(
-            np.array(calc_atoms.get_cell(complete=True)), 
-            dtype=self.precision, 
-            device=self.device
-        ) if calc_atoms.pbc.any() else None
-        
+        atomic_numbers = calc_atoms.get_atomic_numbers()
+        wrapped_positions = calc_atoms.get_positions(wrap=True)
+        cell_array = np.array(calc_atoms.get_cell(complete=True))
+        z = torch.tensor(atomic_numbers, dtype=torch.long, device=self.device)
         natoms = torch.tensor(
             [len(calc_atoms)], 
             dtype=torch.int64, 
@@ -106,8 +180,67 @@ class AlphaNetCalculator(Calculator):
         batch = torch.zeros_like(z).to(self.device)
 
         # --- Run Model Inference ---
-        with torch.set_grad_enabled(self.config.compute_forces):
-            energy, forces, stress = self.model(pos, z, batch, natoms, cell, "infer")
+        use_neighbor_cache = (
+            self.reuse_neighbors
+            and self.supports_neighbor_cache
+            and calc_atoms.pbc.any()
+            and not needs_stress
+        )
+        positions_for_model = wrapped_positions
+        if use_neighbor_cache:
+            positions_for_model = self._align_positions_to_reference(
+                wrapped_positions,
+                cell_array,
+                calc_atoms.pbc,
+            )
+        pos = torch.tensor(
+            positions_for_model,
+            dtype=self.precision,
+            device=self.device,
+            requires_grad=grad_enabled,
+        )
+        cell = torch.tensor(
+            cell_array,
+            dtype=self.precision,
+            device=self.device
+        ) if calc_atoms.pbc.any() else None
+        with torch.set_grad_enabled(grad_enabled):
+            if use_neighbor_cache:
+                topology = self._build_or_reuse_topology(
+                    positions=positions_for_model,
+                    cell_array=cell_array,
+                    numbers=atomic_numbers,
+                    pbc=calc_atoms.pbc,
+                    pos=pos,
+                    natoms=natoms,
+                )
+                graph_data = graph_from_neighbor_topology(
+                    pos=pos,
+                    z=z,
+                    natoms=natoms,
+                    batch=batch,
+                    topology=topology,
+                    cell=cell,
+                    cutoff=self.config.cutoff,
+                    dtype=self.precision,
+                )
+                energy, forces, stress = self.model.forward_graph(
+                    graph_data,
+                    prefix="infer",
+                    compute_forces=needs_forces,
+                    compute_stress=False,
+                )
+            else:
+                energy, forces, stress = self.model(
+                    pos,
+                    z,
+                    batch,
+                    natoms,
+                    cell,
+                    "infer",
+                    compute_forces=needs_forces,
+                    compute_stress=needs_stress,
+                )
         
         # --- Store Results ---
         self.results['energy'] = energy.detach().cpu().item()
@@ -127,5 +260,3 @@ class AlphaNetCalculator(Calculator):
                 stress_matrix[0, 2],  # xz
                 stress_matrix[0, 1]   # xy
             ])
-
-

--- a/alphanet/infer/calc.py
+++ b/alphanet/infer/calc.py
@@ -80,7 +80,7 @@ class AlphaNetCalculator(Calculator):
 
         # --- Prepare Tensors for the Model ---
         z = torch.tensor(
-            [atomic_numbers[atom.symbol] for atom in calc_atoms], 
+            calc_atoms.get_atomic_numbers(), 
             dtype=torch.long, 
             device=self.device
         )
@@ -93,7 +93,7 @@ class AlphaNetCalculator(Calculator):
        
         # Cell should only be provided if the system is periodic
         cell = torch.tensor(
-            calc_atoms.get_cell(complete=True), 
+            np.array(calc_atoms.get_cell(complete=True)), 
             dtype=self.precision, 
             device=self.device
         ) if calc_atoms.pbc.any() else None

--- a/alphanet/infer/calc.py
+++ b/alphanet/infer/calc.py
@@ -23,7 +23,6 @@ class AlphaNetCalculator(Calculator):
         precision='32',
         reuse_neighbors=True,
         skin=0.5,
-        max_num_neighbors_threshold=50,
         **kwargs,
     ):
         """
@@ -34,6 +33,8 @@ class AlphaNetCalculator(Calculator):
             config (object): Model configuration object.
             device (str): Device to run the model on ('cpu' or 'cuda').
             precision (str): Precision for calculations ('32' for float, '64' for double).
+            reuse_neighbors (bool): Whether to cache and reuse the neighbor list.
+            skin (float): Skin distance (Angstrom) for neighbor list caching.
             **kwargs: Additional arguments for the base ASE Calculator.
         """
         Calculator.__init__(self, **kwargs)
@@ -62,7 +63,6 @@ class AlphaNetCalculator(Calculator):
         self.reuse_neighbors = reuse_neighbors
         self.supports_neighbor_cache = hasattr(self.model, "forward_graph")
         self.skin = max(float(skin), 0.0)
-        self.max_num_neighbors_threshold = max_num_neighbors_threshold
         self._neighbor_topology = None
         self._reference_positions = None
         self._reference_cell = None
@@ -139,7 +139,6 @@ class AlphaNetCalculator(Calculator):
                 cell=torch.tensor(cell_array, dtype=self.precision, device=self.device).detach(),
                 cutoff=self.config.cutoff,
                 skin=self.skin,
-                max_num_neighbors_threshold=self.max_num_neighbors_threshold,
                 precision=self.precision,
                 numbers=numbers,
             )

--- a/alphanet/models/alphanet.py
+++ b/alphanet/models/alphanet.py
@@ -462,7 +462,16 @@ class AlphaNet(nn.Module):
             if hasattr(layer, 'reset_parameters'):
                 layer.reset_parameters()
 
-    def forward(self, data: GraphData, prefix: str):
+    def forward(
+        self,
+        data: GraphData,
+        prefix: str,
+        compute_forces: Optional[bool] = None,
+        compute_stress: Optional[bool] = None,
+        return_atom_energy: bool = False,
+    ):
+        compute_forces = self.compute_forces if compute_forces is None else compute_forces
+        compute_stress = self.compute_stress if compute_stress is None else compute_stress
         pos = data.pos
         batch = data.batch
         z = data.z.long()
@@ -539,24 +548,33 @@ class AlphaNet(nn.Module):
         else:
             raise ValueError(f"Unexpected shape of s: {s.shape}")
 
-        s = scatter(s, batch, dim=0, reduce=self.readout).squeeze()
+        atom_energy = s.squeeze(-1) if s.dim() == 2 and s.size(-1) == 1 else s
+        total_energy = scatter(atom_energy, batch, dim=0, reduce=self.readout).squeeze()
         
         if self.use_sigmoid:
-            s = torch.sigmoid((s - 0.5) * 5)
+            if return_atom_energy:
+                raise ValueError("Per-atom energy is not defined when sigmoid readout is enabled")
+            total_energy = torch.sigmoid((total_energy - 0.5) * 5)
             
-        if self.compute_forces and self.compute_stress:
+        if compute_forces and compute_stress:
             if data.displacement is not None:
-              stress, forces = self.cal_stress_and_force(s, pos, data.displacement, data.cell, prefix)
+              stress, forces = self.cal_stress_and_force(total_energy, pos, data.displacement, data.cell, prefix)
               stress = stress.view(-1, 3)
             else:
                 stress = None
                 forces = None
-            return s, forces, stress
-        elif self.compute_forces:
-            forces = self.cal_forces(s, pos, prefix)
-            return s, forces, None
-        
-        return s, None, None
+            if return_atom_energy:
+                return total_energy, forces, stress, atom_energy
+            return total_energy, forces, stress
+        elif compute_forces:
+            forces = self.cal_forces(total_energy, pos, prefix)
+            if return_atom_energy:
+                return total_energy, forces, None, atom_energy
+            return total_energy, forces, None
+
+        if return_atom_energy:
+            return total_energy, None, None, atom_energy
+        return total_energy, None, None
     
     def cal_forces(self, energy, positions, prefix: str = 'infer'):
         graph = (prefix == "train")

--- a/alphanet/models/alphanet.py
+++ b/alphanet/models/alphanet.py
@@ -276,13 +276,13 @@ class EquiMessagePassing(MessagePassing):
 
         phi = torch.complex(real, imagine)
         q = phi
-        a = torch.ones(q.shape[0], 1, (self.hidden_channels_chi) // self.head, device=self.device, dtype=self.complex_type)
+        a = torch.ones(q.shape[0], 1, (self.hidden_channels_chi) // self.head, device=q.device, dtype=self.complex_type)
         kernel = (torch.complex(self.kernel_real, self.kernel_imag) / math.sqrt((self.hidden_channels) // self.head)).expand(q.shape[0], -1, -1, -1)
-        
+
         equation = 'ijl, ijlk->ik'
         conv = torch.einsum(equation, torch.cat([a, q], dim=1), kernel.to(self.complex_type))
         a = 1.0 * self.activation(self.diagonal(rbfh_ij))
-        b = a.unsqueeze(-1) * self.diachi1.unsqueeze(0).unsqueeze(0) + torch.ones(kernel.shape[0], self.chi2, self.chi1, device=self.device)
+        b = a.unsqueeze(-1) * self.diachi1.unsqueeze(0).unsqueeze(0) + torch.ones(kernel.shape[0], self.chi2, self.chi1, device=rbfh_ij.device)
         dia = self.dia(b)
         
         equation = 'ik,ikl->il'

--- a/alphanet/models/graph.py
+++ b/alphanet/models/graph.py
@@ -1,7 +1,9 @@
+from dataclasses import dataclass
+from typing import List, NamedTuple, Optional, Tuple
+
 import torch
 from torch import Tensor
-from typing import Optional, Tuple, NamedTuple, List
-from torch_scatter import  segment_coo, segment_csr
+from torch_scatter import segment_coo, segment_csr
 
 
 
@@ -17,6 +19,18 @@ class GraphData(NamedTuple):
     cell_offsets: Tensor = None
     displacement: Optional[Tensor] = None
     pbc: Optional[Tensor] = None
+
+
+@dataclass
+class NeighborTopology:
+    edge_index: Tensor
+    cell_offsets: Tensor
+    neighbors: Tensor
+    reference_positions: Tensor
+    reference_cell: Tensor
+    cutoff: float
+    skin: float
+    max_num_neighbors_threshold: int
 
 def get_max_neighbors_mask(
    natoms: Tensor,
@@ -325,6 +339,108 @@ def get_pbc_distances(
 
     return out
 
+
+def build_neighbor_topology(
+    pos: Tensor,
+    natoms: Tensor,
+    cell: Tensor,
+    cutoff: float,
+    skin: float = 0.0,
+    max_num_neighbors_threshold: int = 50,
+    pbc: Optional[List[bool]] = None,
+    precision: torch.dtype = torch.float32,
+) -> NeighborTopology:
+    cell = check_and_reshape_cell(cell)
+    radius = cutoff + max(skin, 0.0)
+    edge_index, cell_offsets, neighbors = radius_graph_pbc(
+        pos=pos,
+        natoms=natoms,
+        cell=cell,
+        radius=radius,
+        max_num_neighbors_threshold=max_num_neighbors_threshold,
+        pbc=pbc,
+        precision=precision,
+    )
+    return NeighborTopology(
+        edge_index=edge_index,
+        cell_offsets=cell_offsets,
+        neighbors=neighbors,
+        reference_positions=pos.detach().clone(),
+        reference_cell=cell.detach().clone(),
+        cutoff=cutoff,
+        skin=max(skin, 0.0),
+        max_num_neighbors_threshold=max_num_neighbors_threshold,
+    )
+
+
+def _update_edge_geometry(
+    pos: Tensor,
+    batch: Tensor,
+    edge_index: Tensor,
+    cell: Tensor,
+    cell_offsets: Tensor,
+    precision: torch.dtype = torch.float32,
+    cutoff: Optional[float] = None,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    row = edge_index[0]
+    col = edge_index[1]
+    edge_batch = batch[col]
+    cell_per_edge = cell[edge_batch]
+    offsets = (
+        cell_offsets.to(precision)
+        .view(-1, 1, 3)
+        .bmm(cell_per_edge.to(precision))
+        .view(-1, 3)
+    )
+    distance_vectors = pos[row] - pos[col] + offsets
+    distances = distance_vectors.norm(dim=-1, p=2)
+    valid_mask = distances > 0
+    if cutoff is not None:
+        valid_mask = torch.logical_and(valid_mask, distances <= cutoff)
+    edge_index = edge_index[:, valid_mask]
+    cell_offsets = cell_offsets[valid_mask]
+    distances = distances[valid_mask]
+    distance_vectors = distance_vectors[valid_mask]
+    return edge_index, cell_offsets, distances, distance_vectors
+
+
+def graph_from_neighbor_topology(
+    pos: Tensor,
+    z: Tensor,
+    natoms: Tensor,
+    batch: Tensor,
+    topology: NeighborTopology,
+    cell: Optional[Tensor] = None,
+    displacement: Optional[Tensor] = None,
+    cutoff: Optional[float] = None,
+    dtype: torch.dtype = torch.float32,
+) -> GraphData:
+    precision = dtype
+    pos = pos.to(precision)
+    z = z.long()
+    cell = check_and_reshape_cell(cell)
+    edge_index, cell_offsets, dist, vecs = _update_edge_geometry(
+        pos=pos,
+        batch=batch,
+        edge_index=topology.edge_index,
+        cell=cell,
+        cell_offsets=topology.cell_offsets,
+        precision=precision,
+        cutoff=topology.cutoff if cutoff is None else cutoff,
+    )
+    return GraphData(
+        pos=pos,
+        z=z,
+        natoms=natoms,
+        batch=batch,
+        edge_index=edge_index,
+        edge_attr=dist,
+        edge_vec=vecs,
+        cell=cell,
+        cell_offsets=cell_offsets,
+        displacement=displacement,
+    )
+
 # Borrowed from MACE
 def get_symmetric_displacement(  
         positions: torch.Tensor,
@@ -398,41 +514,31 @@ def process_positions_and_edges(
         displacement = None
    
     cell = check_and_reshape_cell(cell)
-    
-    if use_pbc and cell is not None:
-   
-        edge_index, cell_offsets, neighbors = radius_graph_pbc(
-            pos, natoms, cell, cutoff, max_num_neighbors_threshold=50, precision = precision
+
+    if not use_pbc or cell is None:
+        raise ValueError(
+            "None PBC is not supporting yet, as radius graph is not compilable with jit"
         )
-        #print(edge_index)
-        out = get_pbc_distances(
-            pos,
-            edge_index,
-            cell,
-            cell_offsets,
-            neighbors,
-            return_distance_vec=True,
-            precision = precision
-        )
-        edge_index = out["edge_index"]
-        dist = out["distances"]
-        vecs = out["distance_vec"]
-    
-    else:
-      raise ValueError(f"None PBC is not supporting yet, as radius graph is not compilable with jit")
-    
-    
-    return GraphData(
+
+    topology = build_neighbor_topology(
+        pos=pos,
+        natoms=natoms,
+        cell=cell,
+        cutoff=cutoff,
+        skin=0.0,
+        max_num_neighbors_threshold=50,
+        precision=precision,
+    )
+    return graph_from_neighbor_topology(
         pos=pos,
         z=z,
         natoms=natoms,
         batch=batch,
-        edge_index=edge_index,
-        edge_attr=dist,
-        edge_vec=vecs,
+        topology=topology,
         cell=cell,
-        cell_offsets=cell_offsets,
         displacement=displacement,
+        cutoff=cutoff,
+        dtype=precision,
     )
 
 

--- a/alphanet/models/graph.py
+++ b/alphanet/models/graph.py
@@ -6,8 +6,6 @@ import torch
 from ase import Atoms
 from matscipy.neighbours import neighbour_list
 from torch import Tensor
-from torch_scatter import segment_coo, segment_csr
-
 
 
 class GraphData(NamedTuple):
@@ -15,7 +13,7 @@ class GraphData(NamedTuple):
     batch: Tensor
     z: Tensor
     natoms: Tensor
-    edge_index: Tensor#Tuple[Tensor, Tensor]
+    edge_index: Tensor
     edge_attr: Tensor
     edge_vec: Tensor
     cell: Tensor = None
@@ -33,7 +31,6 @@ class NeighborTopology:
     reference_cell: Tensor
     cutoff: float
     skin: float
-    max_num_neighbors_threshold: int
 
 
 def _to_numpy_array(data) -> np.ndarray:
@@ -42,45 +39,11 @@ def _to_numpy_array(data) -> np.ndarray:
     return np.asarray(data)
 
 
-def _apply_max_neighbors_threshold_numpy(
-    num_atoms: int,
-    index_i: np.ndarray,
-    atom_distance_sqr: np.ndarray,
-    max_num_neighbors_threshold: int,
-) -> np.ndarray:
-    if (
-        max_num_neighbors_threshold <= 0
-        or index_i.size == 0
-        or num_atoms == 0
-    ):
-        return np.ones(index_i.shape[0], dtype=bool)
-
-    counts = np.bincount(index_i, minlength=num_atoms)
-    if counts.max(initial=0) <= max_num_neighbors_threshold:
-        return np.ones(index_i.shape[0], dtype=bool)
-
-    mask = np.zeros(index_i.shape[0], dtype=bool)
-    start = 0
-    for count in counts:
-        end = start + count
-        if count <= max_num_neighbors_threshold:
-            mask[start:end] = True
-        elif count > 0:
-            local_order = np.argsort(
-                atom_distance_sqr[start:end],
-                kind="stable",
-            )[:max_num_neighbors_threshold]
-            mask[start + local_order] = True
-        start = end
-    return mask
-
-
 def _build_single_image_topology_matscipy(
     positions: np.ndarray,
     cell: np.ndarray,
     numbers: np.ndarray,
     radius: float,
-    max_num_neighbors_threshold: int,
     pbc: np.ndarray,
     edge_source_first: bool,
 ) -> Tuple[np.ndarray, np.ndarray, int]:
@@ -90,8 +53,8 @@ def _build_single_image_topology_matscipy(
         cell=cell,
         pbc=pbc,
     )
-    index_i, index_j, shift, distance = neighbour_list(
-        quantities="ijSd",
+    index_i, index_j, shift = neighbour_list(
+        quantities="ijS",
         atoms=atoms,
         cutoff=radius,
     )
@@ -99,28 +62,11 @@ def _build_single_image_topology_matscipy(
     index_i = np.asarray(index_i, dtype=np.int64)
     index_j = np.asarray(index_j, dtype=np.int64)
     shift = np.asarray(shift, dtype=np.int32)
-    atom_distance_sqr = np.square(np.asarray(distance, dtype=np.float64))
 
     if index_i.size == 0:
         edge_index = np.empty((2, 0), dtype=np.int64)
         cell_offsets = np.empty((0, 3), dtype=np.int32)
         return edge_index, cell_offsets, 0
-
-    order = np.argsort(index_i, kind="stable")
-    index_i = index_i[order]
-    index_j = index_j[order]
-    shift = shift[order]
-    atom_distance_sqr = atom_distance_sqr[order]
-
-    mask = _apply_max_neighbors_threshold_numpy(
-        num_atoms=positions.shape[0],
-        index_i=index_i,
-        atom_distance_sqr=atom_distance_sqr,
-        max_num_neighbors_threshold=max_num_neighbors_threshold,
-    )
-    index_i = index_i[mask]
-    index_j = index_j[mask]
-    shift = shift[mask]
 
     if edge_source_first:
         edge_index = np.stack((index_j, index_i), axis=0)
@@ -129,312 +75,18 @@ def _build_single_image_topology_matscipy(
 
     return edge_index, shift, int(index_i.shape[0])
 
-def get_max_neighbors_mask(
-   natoms: Tensor,
-   index: Tensor,
-   atom_distance: Tensor,
-   max_num_neighbors_threshold: int,
-   precision: torch.dtype
-) :
-    """
-    Give a mask that filters out edges so that each atom has at most
-    `max_num_neighbors_threshold` neighbors.
-    Assumes that `index` is sorted.
-    """
-    device = natoms.device
-    num_atoms = natoms.sum()
-
-    # Get number of neighbors
-    # segment_coo assumes sorted index
-    ones = index.new_ones(1).expand_as(index)
-    num_neighbors = segment_coo(ones, index, dim_size=num_atoms)
-    max_num_neighbors = num_neighbors.max()
-    num_neighbors_thresholded = num_neighbors.clamp(
-        max=max_num_neighbors_threshold
-    )
-
-    # Get number of (thresholded) neighbors per image
-    image_indptr = torch.zeros(
-        natoms.shape[0] + 1, device=device, dtype=torch.long
-    )
-    image_indptr[1:] = torch.cumsum(natoms, dim=0)
-    num_neighbors_image = segment_csr(num_neighbors_thresholded, image_indptr)
-
-    # If max_num_neighbors is below the threshold, return early
-    if (
-        max_num_neighbors <= max_num_neighbors_threshold
-        or max_num_neighbors_threshold <= 0
-    ):
-        mask_num_neighbors = torch.tensor(
-            [True], dtype=torch.bool, device=device
-        ).expand_as(index)
-        return mask_num_neighbors, num_neighbors_image
-
-    # Create a tensor of size [num_atoms, max_num_neighbors] to sort the distances of the neighbors.
-    # Fill with infinity so we can easily remove unused distances later.
-    #distance_sort = torch.full(
-     #   [num_atoms * max_num_neighbors], np.inf, device=device
-    #)
-    distance_sort = torch.ones(
-    num_atoms * max_num_neighbors,
-    device=device
-     ) * float('inf')
-    distance_sort = distance_sort.to(precision)
-    # Create an index map to map distances from atom_distance to distance_sort
-    # index_sort_map assumes index to be sorted
-    index_neighbor_offset = torch.cumsum(num_neighbors, dim=0) - num_neighbors
-    index_neighbor_offset_expand = torch.repeat_interleave(
-        index_neighbor_offset, num_neighbors
-    )
-    index_sort_map = (
-        index * max_num_neighbors
-        + torch.arange(len(index), device=device)
-        - index_neighbor_offset_expand
-    )
-    distance_sort.index_copy_(0, index_sort_map, atom_distance)
-    distance_sort = distance_sort.view(num_atoms, max_num_neighbors)
-
-    # Sort neighboring atoms based on distance
-    distance_sort, index_sort = torch.sort(distance_sort, dim=1)
-    # Select the max_num_neighbors_threshold neighbors that are closest
-    distance_sort = distance_sort[:, :max_num_neighbors_threshold]
-    index_sort = index_sort[:, :max_num_neighbors_threshold]
-
-    # Offset index_sort so that it indexes into index
-    index_sort = index_sort + index_neighbor_offset.view(-1, 1).expand(
-        -1, max_num_neighbors_threshold
-    )
-    # Remove "unused pairs" with infinite distances
-    mask_finite = torch.isfinite(distance_sort)
-    index_sort = torch.masked_select(index_sort, mask_finite)
-
-    # At this point index_sort contains the index into index of the
-    # closest max_num_neighbors_threshold neighbors per atom
-    # Create a mask to remove all pairs not in index_sort
-    mask_num_neighbors = torch.zeros(len(index), device=device, dtype=torch.bool)
-    mask_num_neighbors.index_fill_(0, index_sort, torch.tensor(True, device=device))
-
-    return mask_num_neighbors, num_neighbors_image
 
 def check_and_reshape_cell(cell: Optional[torch.Tensor]) -> torch.Tensor:
-   
     if cell is None:
-        return torch.eye(3, dtype=torch.float32).unsqueeze(0) 
-    
+        return torch.eye(3, dtype=torch.float32).unsqueeze(0)
 
     if cell.dim() == 2 and cell.size(0) % 3 == 0 and cell.size(1) == 3:
         batch_size = cell.size(0) // 3
         cell = cell.reshape(batch_size, 3, 3)
     elif cell.dim() != 3 or cell.size(1) != 3 or cell.size(2) != 3:
         raise ValueError(f"Invalid cell shape. Expected (batch_size, 3, 3), but got {cell.size()}")
-    
+
     return cell
-
-def radius_graph_pbc(
-   pos: Tensor,
-   natoms: Tensor,
-   cell: Tensor, 
-   radius: float,
-   max_num_neighbors_threshold: int,
-   pbc: Optional[List[bool]] = None,
-   precision: torch.dtype = torch.float32
-):
-    if pbc is None:
-        pbc = [True, True, True]
-    device = pos.device
-    batch_size = len(natoms)
-    atom_pos = pos
-    num_atoms_per_image = natoms
-    num_atoms_per_image_sqr = (num_atoms_per_image**2).long()
-    index_offset = (
-        torch.cumsum(num_atoms_per_image, dim=0) - num_atoms_per_image
-    )
-    index_offset_expand = torch.repeat_interleave(
-        index_offset, num_atoms_per_image_sqr
-    )
-    num_atoms_per_image_expand = torch.repeat_interleave(
-        num_atoms_per_image, num_atoms_per_image_sqr
-    )
-
-    # Compute a tensor containing sequences of numbers that range from 0 to num_atoms_per_image_sqr for each image
-    # that is used to compute indices for the pairs of atoms. This is a very convoluted way to implement
-    # the following (but 10x faster since it removes the for loop)
-    # for batch_idx in range(batch_size):
-    #    batch_count = torch.cat([batch_count, torch.arange(num_atoms_per_image_sqr[batch_idx], device=device)], dim=0)
-    num_atom_pairs = torch.sum(num_atoms_per_image_sqr)
-    index_sqr_offset = (
-        torch.cumsum(num_atoms_per_image_sqr, dim=0) - num_atoms_per_image_sqr
-    )
-    index_sqr_offset = torch.repeat_interleave(
-        index_sqr_offset, num_atoms_per_image_sqr
-    )
-    atom_count_sqr = (
-        torch.arange(num_atom_pairs, device=device) - index_sqr_offset
-    )
-
-    # Compute the indices for the pairs of atoms (using division and mod)
-    # If the systems get too large this apporach could run into numerical precision issues
-    index1 = (
-        torch.div(
-            atom_count_sqr, num_atoms_per_image_expand, rounding_mode="floor"
-        )
-    ) + index_offset_expand
-    index2 = (
-        atom_count_sqr % num_atoms_per_image_expand
-    ) + index_offset_expand
-    # Get the positions for each atom
-    pos1 = torch.index_select(atom_pos, 0, index1)
-    pos2 = torch.index_select(atom_pos, 0, index2)
-
-    # Calculate required number of unit cells in each direction.
-    # Smallest distance between planes separated by a1 is
-    # 1 / ||(a2 x a3) / V||_2, since a2 x a3 is the area of the plane.
-    # Note that the unit cell volume V = a1 * (a2 x a3) and that
-    # (a2 x a3) / V is also the reciprocal primitive vector
-    # (crystallographer's definition).
-    #print(data.cell.shape)
-    cross_a2a3 = torch.cross(cell[:, 1], cell[:, 2], dim=-1)
-    cell_vol = torch.sum(cell[:, 0] * cross_a2a3, dim=-1, keepdim=True)
-
-    if pbc[0]:
-        inv_min_dist_a1 = torch.norm(cross_a2a3 / cell_vol, dim=-1)
-        rep_a1 = torch.ceil(radius * inv_min_dist_a1)
-    else:
-        rep_a1 = cell.new_zeros(1)
-
-    if pbc[1]:
-        cross_a3a1 = torch.cross(cell[:, 2], cell[:, 0], dim=-1)
-        inv_min_dist_a2 = torch.norm(cross_a3a1 / cell_vol, dim=-1)
-        rep_a2 = torch.ceil(radius * inv_min_dist_a2)
-    else:
-        rep_a2 = cell.new_zeros(1)
-
-    if pbc[2]:
-        cross_a1a2 = torch.cross(cell[:, 0], cell[:, 1], dim=-1)
-        inv_min_dist_a3 = torch.norm(cross_a1a2 / cell_vol,  dim=-1)
-        rep_a3 = torch.ceil(radius * inv_min_dist_a3)
-    else:
-        rep_a3 = cell.new_zeros(1)
-
-    # Take the max over all images for uniformity. This is essentially padding.
-    # Note that this can significantly increase the number of computed distances
-    # if the required repetitions are very different between images
-    # (which they usually are). Changing this to sparse (scatter) operations
-    # might be worth the effort if this function becomes a bottleneck.
-    max_rep = [int(rep_a1.max()), int(rep_a2.max()), int(rep_a3.max())]
-
-    # Tensor of unit cells
-    cells_per_dim = [
-        torch.arange(-rep, rep + 1, device=device, dtype=precision)
-        for rep in max_rep
-    ]
-    unit_cell = torch.cartesian_prod(cells_per_dim[0],cells_per_dim[1], cells_per_dim[2])
-    num_cells = len(unit_cell)
-    unit_cell_per_atom = unit_cell.view(1, num_cells, 3).repeat(
-        len(index2), 1, 1
-    )
-    unit_cell = torch.transpose(unit_cell, 0, 1)
-    unit_cell_batch = unit_cell.view(1, 3, num_cells).expand(
-        batch_size, -1, -1
-    )
-   
-    # Compute the x, y, z positional offsets for each cell in each image
-    data_cell = torch.transpose(cell, 1, 2)
-    
-    pbc_offsets = torch.bmm(data_cell, unit_cell_batch)
-    pbc_offsets_per_atom = torch.repeat_interleave(
-        pbc_offsets, num_atoms_per_image_sqr, dim=0
-    )
-
-    # Expand the positions and indices for the 9 cells
-    pos1 = pos1.view(-1, 3, 1).expand(-1, -1, num_cells)
-    pos2 = pos2.view(-1, 3, 1).expand(-1, -1, num_cells)
-    index1 = index1.view(-1, 1).repeat(1, num_cells).view(-1)
-    index2 = index2.view(-1, 1).repeat(1, num_cells).view(-1)
-    # Add the PBC offsets for the second atom
-    pos2 = pos2 + pbc_offsets_per_atom
-
-    # Compute the squared distance between atoms
-    atom_distance_sqr = torch.sum((pos1 - pos2) ** 2, dim=1)
-    atom_distance_sqr = atom_distance_sqr.view(-1)
-
-    # Remove pairs that are too far apart
-    mask_within_radius = torch.le(atom_distance_sqr, radius * radius)
-    # Remove pairs with the same atoms (distance = 0.0)
-    mask_not_same = torch.gt(atom_distance_sqr, 0.0001)
-    mask = torch.logical_and(mask_within_radius, mask_not_same)
-    index1 = torch.masked_select(index1, mask)
-    index2 = torch.masked_select(index2, mask)
-    unit_cell = torch.masked_select(
-        unit_cell_per_atom.view(-1, 3), mask.view(-1, 1).expand(-1, 3)
-    )
-    unit_cell = unit_cell.view(-1, 3)
-    atom_distance_sqr = torch.masked_select(atom_distance_sqr, mask)
-
-    mask_num_neighbors, num_neighbors_image = get_max_neighbors_mask(
-        natoms=natoms,
-        index=index1,
-        atom_distance=atom_distance_sqr,
-        max_num_neighbors_threshold=max_num_neighbors_threshold,
-        precision = precision
-    )
-
-    if not torch.all(mask_num_neighbors):
-        # Mask out the atoms to ensure each atom has at most max_num_neighbors_threshold neighbors
-        index1 = torch.masked_select(index1, mask_num_neighbors)
-        index2 = torch.masked_select(index2, mask_num_neighbors)
-        unit_cell = torch.masked_select(
-            unit_cell.view(-1, 3), mask_num_neighbors.view(-1, 1).expand(-1, 3)
-        )
-        unit_cell = unit_cell.view(-1, 3)
-
-    edge_index = torch.stack((index2, index1))
-
-    return edge_index, unit_cell, num_neighbors_image
-    
-def get_pbc_distances(
-    pos: Tensor,
-    edge_index: Tensor,
-    cell: Tensor,
-    cell_offsets: Tensor,
-    neighbors: Tensor,
-    return_offsets: bool = False,
-    return_distance_vec: bool = False,
-    precision: torch.dtype = torch.float32
-):
-    row= edge_index[0]
-    col = edge_index[1]
-
-    distance_vectors = pos[row] - pos[col]
-
-    # correct for pbc
-    neighbors = neighbors.to(cell.device)
-    cell = torch.repeat_interleave(cell, neighbors, dim=0)
-    offsets = cell_offsets.to(precision).view(-1, 1, 3).bmm(cell.to(precision)).view(-1, 3)
-    distance_vectors += offsets
-
-    # compute distances
-    distances = distance_vectors.norm(dim=-1 , p=2)
-
-    # redundancy: remove zero distances
-    nonzero_idx = torch.arange(len(distances), device=distances.device)[
-        distances != 0
-    ]
-    edge_index = edge_index[:, nonzero_idx]
-    distances = distances[nonzero_idx]
-
-    out = {
-        "edge_index": edge_index,
-        "distances": distances,
-    }
-
-    if return_distance_vec:
-        out["distance_vec"] = distance_vectors[nonzero_idx]
-
-    if return_offsets:
-        out["offsets"] = offsets[nonzero_idx]
-
-    return out
 
 
 def build_neighbor_topology(
@@ -443,7 +95,6 @@ def build_neighbor_topology(
     cell: Tensor,
     cutoff: float,
     skin: float = 0.0,
-    max_num_neighbors_threshold: int = 50,
     pbc: Optional[List[bool]] = None,
     precision: torch.dtype = torch.float32,
     numbers: Optional[Tensor] = None,
@@ -478,7 +129,6 @@ def build_neighbor_topology(
             cell=cell_np[image_index],
             numbers=numbers_np[image_slice],
             radius=radius,
-            max_num_neighbors_threshold=max_num_neighbors_threshold,
             pbc=pbc_array,
             edge_source_first=edge_source_first,
         )
@@ -514,7 +164,6 @@ def build_neighbor_topology(
         reference_cell=cell.detach().clone(),
         cutoff=cutoff,
         skin=max(skin, 0.0),
-        max_num_neighbors_threshold=max_num_neighbors_threshold,
     )
 
 
@@ -586,8 +235,9 @@ def graph_from_neighbor_topology(
         displacement=displacement,
     )
 
+
 # Borrowed from MACE
-def get_symmetric_displacement(  
+def get_symmetric_displacement(
         positions: torch.Tensor,
         cell: Optional[torch.Tensor],
         num_graphs: int,
@@ -600,18 +250,18 @@ def get_symmetric_displacement(
                 dtype=positions.dtype,
                 device=positions.device,
             )
-        
+
         displacement = torch.zeros(
             (num_graphs, 3, 3),
             dtype=positions.dtype,
             device=positions.device,
-         )
-      
+        )
+
         displacement.requires_grad_(True)
         symmetric_displacement = 0.5 * (
             displacement + displacement.transpose(-1, -2)
         )
-    
+
         positions = positions + torch.einsum(
             "be,bec->bc", positions, symmetric_displacement[batch]
         )
@@ -619,6 +269,7 @@ def get_symmetric_displacement(
         cell = cell + torch.matmul(cell, symmetric_displacement)
         cell.view(-1, 3)
         return positions, cell, displacement
+
 
 def process_positions_and_edges(
     pos: Tensor,
@@ -633,36 +284,26 @@ def process_positions_and_edges(
     dtype: torch.dtype = torch.float32
 ) -> GraphData:
     """
-    Process atomic positions and compute edges with optional PBC support.
-    We found that non-pbc graph is not compatible with jit compile, so we don't support that for now, please create a large cell if you want to do non-pbc calculation.
-    Args:
-        data: Input data object containing positions, batch info, and other attributes
-        compute_forces: Boolean flag for force computation
-        compute_stress: Boolean flag for stress computation
-        use_pbc: Boolean flag for periodic boundary conditions
-        cutoff: Cutoff radius for neighbor search
-        dtype: torch dtype precision
-        
-    Returns:
-        Data:  Data object containing processed attributes
+    Process atomic positions and compute edges with PBC support.
+
+    Non-PBC mode is not supported directly; create a large vacuum cell instead.
     """
     precision = dtype
     pos = pos.to(precision)
     z = z.long()
-    
+
     if compute_stress:
-        
         pos, cell, displacement = get_symmetric_displacement(
-            pos, cell, num_graphs=int(torch.max(batch))+1, batch=batch
+            pos, cell, num_graphs=int(torch.max(batch)) + 1, batch=batch
         )
     else:
         displacement = None
-   
+
     cell = check_and_reshape_cell(cell)
 
     if not use_pbc or cell is None:
         raise ValueError(
-            "None PBC is not supporting yet, as radius graph is not compilable with jit"
+            "Non-PBC mode is not supported; please create a large vacuum cell."
         )
 
     topology = build_neighbor_topology(
@@ -671,7 +312,6 @@ def process_positions_and_edges(
         cell=cell,
         cutoff=cutoff,
         skin=0.0,
-        max_num_neighbors_threshold=50,
         precision=precision,
         numbers=z,
     )
@@ -685,71 +325,4 @@ def process_positions_and_edges(
         displacement=displacement,
         cutoff=cutoff,
         dtype=precision,
-    )
-
-
-def _process_positions_and_edges(
-    pos: Tensor,
-    z: Tensor,
-    natoms: Tensor,
-    batch: Tensor,
-    cell: Optional[Tensor] = None,
-    compute_stress: bool = False,
-    compute_forces: bool = False,
-    use_pbc: bool = False,
-    cutoff: float = 5.0,
-    dtype: torch.dtype = torch.float32
-) -> GraphData:
-    """
-    Process atomic positions and compute edges with optional PBC support.
-    Added 100 ghost atoms that are not connected to any nodes.
-    """
-    precision = dtype
-    pos = pos.to(precision)
-    z = z.long()
-    num_graphs = int(torch.max(batch)) + 1  # 获取图的数量
-    
-    if compute_stress:
-        new_pos, cell, displacement = get_symmetric_displacement(
-            pos, cell, num_graphs=int(torch.max(batch))+1, batch=batch
-        )
-    else:
-        displacement = None
-   
-    cell = check_and_reshape_cell(cell)
-    
-    if use_pbc and cell is not None:
-        edge_index, cell_offsets, neighbors = radius_graph_pbc(
-            pos, natoms, cell, cutoff, max_num_neighbors_threshold=500, precision=precision
-        )
-        new_pos = pos
-        new_z = z
-        new_batch = batch
-        out = get_pbc_distances(
-            new_pos,
-            edge_index,
-            cell,
-            cell_offsets,
-            neighbors,
-            return_distance_vec=True,
-            precision=precision
-        )
-        edge_index = out["edge_index"]
-        dist = out["distances"]
-        vecs = out["distance_vec"]
-    else:
-        raise ValueError("None PBC is not supporting yet, as radius graph is not compilable with jit")
-    
-    
-    return GraphData(
-        pos=new_pos,
-        z=new_z,
-        natoms=new_natoms,
-        batch=new_batch,
-        edge_index=edge_index, 
-        edge_attr=dist,
-        edge_vec=vecs,
-        cell=cell,
-        cell_offsets=cell_offsets,
-        displacement=displacement,
     )

--- a/alphanet/models/graph.py
+++ b/alphanet/models/graph.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
 from typing import List, NamedTuple, Optional, Tuple
 
+import numpy as np
 import torch
+from ase import Atoms
+from matscipy.neighbours import neighbour_list
 from torch import Tensor
 from torch_scatter import segment_coo, segment_csr
 
@@ -31,6 +34,100 @@ class NeighborTopology:
     cutoff: float
     skin: float
     max_num_neighbors_threshold: int
+
+
+def _to_numpy_array(data) -> np.ndarray:
+    if isinstance(data, torch.Tensor):
+        return data.detach().cpu().numpy()
+    return np.asarray(data)
+
+
+def _apply_max_neighbors_threshold_numpy(
+    num_atoms: int,
+    index_i: np.ndarray,
+    atom_distance_sqr: np.ndarray,
+    max_num_neighbors_threshold: int,
+) -> np.ndarray:
+    if (
+        max_num_neighbors_threshold <= 0
+        or index_i.size == 0
+        or num_atoms == 0
+    ):
+        return np.ones(index_i.shape[0], dtype=bool)
+
+    counts = np.bincount(index_i, minlength=num_atoms)
+    if counts.max(initial=0) <= max_num_neighbors_threshold:
+        return np.ones(index_i.shape[0], dtype=bool)
+
+    mask = np.zeros(index_i.shape[0], dtype=bool)
+    start = 0
+    for count in counts:
+        end = start + count
+        if count <= max_num_neighbors_threshold:
+            mask[start:end] = True
+        elif count > 0:
+            local_order = np.argsort(
+                atom_distance_sqr[start:end],
+                kind="stable",
+            )[:max_num_neighbors_threshold]
+            mask[start + local_order] = True
+        start = end
+    return mask
+
+
+def _build_single_image_topology_matscipy(
+    positions: np.ndarray,
+    cell: np.ndarray,
+    numbers: np.ndarray,
+    radius: float,
+    max_num_neighbors_threshold: int,
+    pbc: np.ndarray,
+    edge_source_first: bool,
+) -> Tuple[np.ndarray, np.ndarray, int]:
+    atoms = Atoms(
+        numbers=numbers,
+        positions=positions,
+        cell=cell,
+        pbc=pbc,
+    )
+    index_i, index_j, shift, distance = neighbour_list(
+        quantities="ijSd",
+        atoms=atoms,
+        cutoff=radius,
+    )
+
+    index_i = np.asarray(index_i, dtype=np.int64)
+    index_j = np.asarray(index_j, dtype=np.int64)
+    shift = np.asarray(shift, dtype=np.int32)
+    atom_distance_sqr = np.square(np.asarray(distance, dtype=np.float64))
+
+    if index_i.size == 0:
+        edge_index = np.empty((2, 0), dtype=np.int64)
+        cell_offsets = np.empty((0, 3), dtype=np.int32)
+        return edge_index, cell_offsets, 0
+
+    order = np.argsort(index_i, kind="stable")
+    index_i = index_i[order]
+    index_j = index_j[order]
+    shift = shift[order]
+    atom_distance_sqr = atom_distance_sqr[order]
+
+    mask = _apply_max_neighbors_threshold_numpy(
+        num_atoms=positions.shape[0],
+        index_i=index_i,
+        atom_distance_sqr=atom_distance_sqr,
+        max_num_neighbors_threshold=max_num_neighbors_threshold,
+    )
+    index_i = index_i[mask]
+    index_j = index_j[mask]
+    shift = shift[mask]
+
+    if edge_source_first:
+        edge_index = np.stack((index_j, index_i), axis=0)
+    else:
+        edge_index = np.stack((index_i, index_j), axis=0)
+
+    return edge_index, shift, int(index_i.shape[0])
 
 def get_max_neighbors_mask(
    natoms: Tensor,
@@ -349,21 +446,69 @@ def build_neighbor_topology(
     max_num_neighbors_threshold: int = 50,
     pbc: Optional[List[bool]] = None,
     precision: torch.dtype = torch.float32,
+    numbers: Optional[Tensor] = None,
+    edge_source_first: bool = True,
 ) -> NeighborTopology:
     cell = check_and_reshape_cell(cell)
     radius = cutoff + max(skin, 0.0)
-    edge_index, cell_offsets, neighbors = radius_graph_pbc(
-        pos=pos,
-        natoms=natoms,
-        cell=cell,
-        radius=radius,
-        max_num_neighbors_threshold=max_num_neighbors_threshold,
-        pbc=pbc,
-        precision=precision,
+    device = pos.device
+    pbc_array = np.asarray(
+        [True, True, True] if pbc is None else pbc,
+        dtype=bool,
+    )
+    natoms_np = _to_numpy_array(natoms).astype(np.int64)
+    pos_np = _to_numpy_array(pos).astype(np.float64, copy=False)
+    cell_np = _to_numpy_array(cell).astype(np.float64, copy=False)
+
+    if numbers is None:
+        numbers_np = np.ones(pos_np.shape[0], dtype=np.int32)
+    else:
+        numbers_np = _to_numpy_array(numbers).astype(np.int32, copy=False)
+
+    edge_indices = []
+    cell_offsets = []
+    num_neighbors_image = []
+
+    atom_offset = 0
+    for image_index, image_natoms in enumerate(natoms_np):
+        image_natoms = int(image_natoms)
+        image_slice = slice(atom_offset, atom_offset + image_natoms)
+        image_edge_index, image_offsets, image_neighbors = _build_single_image_topology_matscipy(
+            positions=pos_np[image_slice],
+            cell=cell_np[image_index],
+            numbers=numbers_np[image_slice],
+            radius=radius,
+            max_num_neighbors_threshold=max_num_neighbors_threshold,
+            pbc=pbc_array,
+            edge_source_first=edge_source_first,
+        )
+        if image_neighbors > 0:
+            image_edge_index = image_edge_index + atom_offset
+            edge_indices.append(torch.from_numpy(image_edge_index))
+            cell_offsets.append(torch.from_numpy(image_offsets))
+        num_neighbors_image.append(image_neighbors)
+        atom_offset += image_natoms
+
+    if edge_indices:
+        edge_index = torch.cat(edge_indices, dim=1).to(
+            device=device,
+            dtype=torch.long,
+        )
+        cell_offsets_tensor = torch.cat(cell_offsets, dim=0).to(
+            device=device,
+            dtype=torch.int32,
+        )
+    else:
+        edge_index = torch.empty((2, 0), device=device, dtype=torch.long)
+        cell_offsets_tensor = torch.empty((0, 3), device=device, dtype=torch.int32)
+    neighbors = torch.tensor(
+        num_neighbors_image,
+        device=device,
+        dtype=torch.long,
     )
     return NeighborTopology(
         edge_index=edge_index,
-        cell_offsets=cell_offsets,
+        cell_offsets=cell_offsets_tensor,
         neighbors=neighbors,
         reference_positions=pos.detach().clone(),
         reference_cell=cell.detach().clone(),
@@ -528,6 +673,7 @@ def process_positions_and_edges(
         skin=0.0,
         max_num_neighbors_threshold=50,
         precision=precision,
+        numbers=z,
     )
     return graph_from_neighbor_topology(
         pos=pos,

--- a/alphanet/models/model.py
+++ b/alphanet/models/model.py
@@ -3,8 +3,10 @@ import time
 from torch import Tensor
 from typing import Optional
 from alphanet.models.alphanet import AlphaNet
-from alphanet.models.graph import process_positions_and_edges
+from alphanet.models.graph import GraphData, process_positions_and_edges
 from alphanet.config import AlphaConfig
+
+
 class AlphaNetWrapper(torch.nn.Module):
     def __init__(
         self,
@@ -17,26 +19,67 @@ class AlphaNetWrapper(torch.nn.Module):
         self.compute_stress = config.compute_stress
         self.use_pbc = config.use_pbc
         self.precision =  torch.float32 if config.dtype == "32" else torch.float64
-    def forward(self, 
+
+    def _resolve_compute_flags(
+        self,
+        compute_forces: Optional[bool],
+        compute_stress: Optional[bool],
+    ):
+        resolved_forces = self.compute_forces if compute_forces is None else compute_forces
+        resolved_stress = self.compute_stress if compute_stress is None else compute_stress
+        return resolved_forces, resolved_stress
+
+    def forward(
+            self,
             pos: Tensor,
             z: Tensor,
             batch: Tensor,
             natoms: Tensor,
             cell: Optional[Tensor] = None,
-            prefix: str = 'infer'):
+            prefix: str = 'infer',
+            compute_forces: Optional[bool] = None,
+            compute_stress: Optional[bool] = None,
+            return_atom_energy: bool = False):
+        compute_forces, compute_stress = self._resolve_compute_flags(
+            compute_forces,
+            compute_stress,
+        )
         processed_data = process_positions_and_edges(
             pos=pos,
             z=z,
             natoms=natoms,
             batch=batch,
             cell=cell,
-            compute_forces=self.compute_forces,
-            compute_stress=self.compute_stress,
+            compute_forces=compute_forces,
+            compute_stress=compute_stress,
             use_pbc=self.use_pbc,
             cutoff=self.cutoff,
             dtype=self.precision
         )
-       
-        output = self.model(processed_data, prefix)
-       
-        return output
+        return self.forward_graph(
+            processed_data,
+            prefix=prefix,
+            compute_forces=compute_forces,
+            compute_stress=compute_stress,
+            return_atom_energy=return_atom_energy,
+        )
+
+    def forward_graph(
+        self,
+        graph_data: GraphData,
+        prefix: str = "infer",
+        compute_forces: Optional[bool] = None,
+        compute_stress: Optional[bool] = None,
+        return_atom_energy: bool = False,
+    ):
+        compute_forces, compute_stress = self._resolve_compute_flags(
+            compute_forces,
+            compute_stress,
+        )
+        return self.model(
+            graph_data,
+            prefix,
+            compute_forces=compute_forces,
+            compute_stress=compute_stress,
+            return_atom_energy=return_atom_energy,
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cu121
 
 numpy==1.26.4
+matscipy==1.1.1
 torch==2.1.2
 torch_geometric
 lightning
@@ -8,5 +9,4 @@ tensorboard
 
 --find-links https://pytorch-geometric.com/whl/torch-2.1.2%2Bcu121.html
 torch_scatter
-
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
         'pyfiglet',
         'rich',
         'ase',
+        'matscipy==1.1.1',
         'rdkit',
         'pydantic',
         'scikit-learn',


### PR DESCRIPTION
This PR updates the ASE-Torch inference path by adding neighbor-cache reuse, keeping efficient energy-only inference, and replacing dense PBC neighbor construction with sparse matscipy neighbor lists.