### PR TITLE
Accelerate ASE inference: real-arithmetic rewrite, CUDA graphs, fused Triton kernels

### DIFF
--- a/alphanet/infer/calc.py
+++ b/alphanet/infer/calc.py
@@ -95,24 +95,40 @@ class AlphaNetCalculator(Calculator):
             return calc_atoms
         return self.atoms
 
-    def _max_displacement_since_rebuild(self, positions, cell, pbc):
+    def _pair_distance_change_bound(self, positions, cell, pbc):
+        """Conservative upper bound on how much any pair distance can have
+        changed since the cached neighbor list was built, including cell
+        deformation (NPT / variable-cell optimization).
+
+        With f/s the current/reference fractional coordinates, C/C_ref the
+        current/reference cells and S the cached integer offsets, any pair
+        vector change decomposes as
+            dv = [(f_j - s_j) - (f_i - s_i)] @ C + (s_j + S - s_i) @ (C - C_ref)
+        so ||dv|| <= 2 * max_i ||aligned_i - s_i @ C||
+                    + (cutoff + skin) * ||inv(C_ref)||_2 * ||C - C_ref||_2,
+        where the second term uses ||v_ref|| <= cutoff + skin for every cached
+        pair (and monotonicity in ||v_ref|| for excluded pairs). The cached
+        list stays valid while this bound does not exceed the skin.
+        """
         if self._reference_positions is None or self._reference_cell is None:
             return float("inf")
-        aligned_positions = self._align_positions_to_reference(positions, cell, pbc)
-        delta_cart = aligned_positions - self._reference_positions
-        distances = np.linalg.norm(delta_cart, axis=1)
-        return float(np.max(distances)) if distances.size else 0.0
+        aligned = self._align_positions_to_reference(positions, cell, pbc)
+        reference_frac = self._reference_positions @ np.linalg.inv(self._reference_cell)
+        internal = aligned - reference_frac @ cell
+        internal_max = float(np.max(np.linalg.norm(internal, axis=1))) if len(internal) else 0.0
+        cell_delta = float(np.linalg.norm(cell - self._reference_cell, ord=2))
+        inv_ref_norm = float(np.linalg.norm(np.linalg.inv(self._reference_cell), ord=2))
+        radius = float(self.config.cutoff) + self.skin
+        return 2.0 * internal_max + radius * inv_ref_norm * cell_delta
 
     def _align_positions_to_reference(self, positions, cell, pbc):
-        if (
-            self._reference_positions is None
-            or self._reference_cell is None
-            or not np.allclose(cell, self._reference_cell, atol=1e-12, rtol=0.0)
-        ):
+        """Map each atom onto the periodic image closest to its reference
+        position. Fractional coordinates are taken in each configuration's own
+        cell, so the mapping remains exact under cell deformation (NPT)."""
+        if self._reference_positions is None or self._reference_cell is None:
             return positions.copy()
-        inverse_cell = np.linalg.inv(cell)
-        current_frac = positions @ inverse_cell
-        reference_frac = self._reference_positions @ inverse_cell
+        current_frac = positions @ np.linalg.inv(cell)
+        reference_frac = self._reference_positions @ np.linalg.inv(self._reference_cell)
         delta_frac = current_frac - reference_frac
         periodic_axes = np.asarray(pbc, dtype=bool)
         delta_frac[:, periodic_axes] -= np.round(delta_frac[:, periodic_axes])
@@ -129,9 +145,9 @@ class AlphaNetCalculator(Calculator):
             return True
         if self._reference_pbc is None or not np.array_equal(np.asarray(pbc, dtype=bool), self._reference_pbc):
             return True
-        if self._reference_cell is None or not np.allclose(cell, self._reference_cell, atol=1e-12, rtol=0.0):
+        if self._reference_cell is None:
             return True
-        return self._max_displacement_since_rebuild(positions, cell, pbc) > (0.5 * self.skin)
+        return self._pair_distance_change_bound(positions, cell, pbc) > self.skin
 
     def _build_or_reuse_topology(self, positions, cell_array, numbers, pbc, pos, natoms):
         if self._should_rebuild_topology(positions, cell_array, numbers, pbc):
@@ -182,11 +198,14 @@ class AlphaNetCalculator(Calculator):
         batch = torch.zeros_like(z).to(self.device)
 
         # --- Run Model Inference ---
+        # The stress path also uses the cached topology: the symmetric
+        # displacement is injected in graph_from_neighbor_topology, so
+        # NPT / variable-cell runs no longer rebuild the neighbor list
+        # from scratch on every step.
         use_neighbor_cache = (
             self.reuse_neighbors
             and self.supports_neighbor_cache
             and calc_atoms.pbc.any()
-            and not needs_stress
         )
         positions_for_model = wrapped_positions
         if use_neighbor_cache:
@@ -225,12 +244,13 @@ class AlphaNetCalculator(Calculator):
                     cell=cell,
                     cutoff=self.config.cutoff,
                     dtype=self.precision,
+                    compute_stress=needs_stress,
                 )
                 energy, forces, stress = self.model.forward_graph(
                     graph_data,
                     prefix="infer",
                     compute_forces=needs_forces,
-                    compute_stress=False,
+                    compute_stress=needs_stress,
                 )
             else:
                 energy, forces, stress = self.model(

--- a/alphanet/infer/calc.py
+++ b/alphanet/infer/calc.py
@@ -1,6 +1,10 @@
+import gc
+import warnings
+
 import numpy as np
 import torch
 from ase.calculators.calculator import Calculator, all_changes
+from alphanet.infer.cuda_graph import CapturedStep
 from alphanet.models.graph import build_neighbor_topology, graph_from_neighbor_topology
 from alphanet.models.model import AlphaNetWrapper
 
@@ -25,6 +29,8 @@ class AlphaNetCalculator(Calculator):
         precision='32',
         reuse_neighbors=True,
         skin=0.5,
+        use_cuda_graph=None,
+        sticky_stress=True,
         **kwargs,
     ):
         """
@@ -37,6 +43,22 @@ class AlphaNetCalculator(Calculator):
             precision (str): Precision for calculations ('32' for float, '64' for double).
             reuse_neighbors (bool): Whether to cache and reuse the neighbor list.
             skin (float): Skin distance (Angstrom) for neighbor list caching.
+            use_cuda_graph (bool | None): Capture the whole step (edge geometry,
+                forward, autograd backward) into a CUDA graph and replay it.
+                None (default) = auto: after the first capture, replay and
+                eager are timed once per (system size, stress mode) and the
+                faster path is kept — graphs win on launch-bound hardware
+                (fast server GPUs), eager wins where kernel execution
+                dominates. True forces graphs, False disables. Capture
+                failure always falls back to eager with a warning.
+            sticky_stress (bool): Once stress has been requested, compute
+                energy+forces+stress in every subsequent calculate() call.
+                ASE optimizers/NPT drivers request E, F and S as three
+                separate calls per step; with sticky stress the first call
+                fills the results cache and the other two are free, so a
+                step costs one forward+backward instead of ~2.5. Pure-MD
+                runs that never ask for stress are unaffected. Call
+                reset_neighbor_cache() to clear the mode.
             **kwargs: Additional arguments for the base ASE Calculator.
         """
         Calculator.__init__(self, **kwargs)
@@ -72,9 +94,34 @@ class AlphaNetCalculator(Calculator):
         self._reference_pbc = None
         self._neighbor_cache_stats = {"rebuilds": 0, "reuses": 0}
 
+        # --- CUDA graph state ---
+        # None = auto: capture, then time replay vs eager once per
+        # (n_atoms, stress-mode) and keep whichever is faster. The static-shape
+        # graph computes ~(1+skin/cutoff)^3 more (masked) edges than the
+        # filtered eager path, so which side wins is hardware- and
+        # size-dependent: graphs win where per-kernel latency dominates.
+        self._graph_auto = use_cuda_graph is None
+        use_graph = True if use_cuda_graph is None else bool(use_cuda_graph)
+        self.use_cuda_graph = use_graph and self.device.type == "cuda"
+        self._captured_step = None
+        self._graph_disabled = False
+        self._graph_choice = {}  # (n_atoms, with_stress) -> bool (auto mode)
+        self._graph_stats = {"captures": 0, "replays": 0, "topo_updates": 0}
+
+        # Sticky stress mode (shared by the eager and CUDA-graph paths): once
+        # stress is requested, every calculate() produces E+F+S so the ASE
+        # E/F/S call battery of optimizers and NPT drivers costs a single
+        # forward+backward per step. reset_neighbor_cache() clears it.
+        self.sticky_stress = bool(sticky_stress)
+        self._stress_sticky = False
+
     @property
     def neighbor_cache_stats(self):
         return dict(self._neighbor_cache_stats)
+
+    @property
+    def cuda_graph_stats(self):
+        return dict(self._graph_stats)
 
     def reset_neighbor_cache(self):
         self._neighbor_topology = None
@@ -82,6 +129,135 @@ class AlphaNetCalculator(Calculator):
         self._reference_cell = None
         self._reference_numbers = None
         self._reference_pbc = None
+        self._stress_sticky = False
+        self._release_captured_step()
+
+    def _release_captured_step(self):
+        if self._captured_step is not None:
+            # Fully destroy the old graph (and its private memory pool) before
+            # any new capture: on torch 2.1 capturing into a pool that still
+            # holds live blocks trips a CUDACachingAllocator assert, and a
+            # failed capture poisons the allocator state for the whole process.
+            self._captured_step = None
+            gc.collect()
+            torch.cuda.synchronize(self.device)
+            # Return the dead graph pool's blocks to the driver — otherwise
+            # they stay reserved and the eager path (or the next capture)
+            # can be pushed into shared-memory spill on small GPUs.
+            torch.cuda.empty_cache()
+
+    def _graph_step_for(self, topology, needs_stress, z, natoms, batch,
+                        n_atoms, positions, cell_array):
+        """Return a ready CapturedStep for this topology/request, or None to
+        use the eager path. Handles (re)capture, cheap topology refresh and
+        (in auto mode) the one-off replay-vs-eager timing decision."""
+        if not self.use_cuda_graph or self._graph_disabled or self.skin <= 0.0:
+            return None
+        # needs_stress already reflects the sticky policy applied in
+        # calculate(); a capture therefore keeps serving the whole E/F/S
+        # battery of an optimizer step with a single replay. Even with the
+        # sticky policy disabled, never downgrade an existing stress capture
+        # to a forces-only one — that would thrash recaptures in optimizer
+        # loops (extra stress outputs are stored and simply go unused).
+        want_stress = needs_stress or (self._captured_step is not None
+                                       and self._captured_step.with_stress)
+        key = (n_atoms, want_stress)
+        if self._graph_auto and self._graph_choice.get(key) is False:
+            return None
+        step = self._captured_step
+        if step is not None and (step.n_atoms != n_atoms
+                                 or step.with_stress != want_stress):
+            self._release_captured_step()
+            step = None
+        if step is not None:
+            if step.topology_ref is not topology:
+                if step.update_topology(topology):
+                    self._graph_stats["topo_updates"] += 1
+                else:
+                    # edge count outgrew the captured capacity -> recapture
+                    self._release_captured_step()
+                    step = None
+        if step is None:
+            try:
+                step = CapturedStep(
+                    model=self.model, topology=topology, z=z, natoms=natoms,
+                    batch=batch, n_atoms=n_atoms, cutoff=self.config.cutoff,
+                    skin=self.skin, precision=self.precision,
+                    device=self.device, with_stress=want_stress,
+                    positions=positions, cell=cell_array,
+                )
+            except Exception as exc:
+                warnings.warn(
+                    f"CUDA graph capture failed ({exc!r}); falling back to "
+                    f"the eager execution path.")
+                self._graph_disabled = True
+                # salvage whatever the aborted capture left behind so the
+                # eager fallback is not pushed into OOM
+                gc.collect()
+                torch.cuda.empty_cache()
+                return None
+            self._captured_step = step
+            self._graph_stats["captures"] += 1
+            if self._graph_auto and key not in self._graph_choice:
+                # Time replay, release the graph (its private pool holds the
+                # full activation memory — timing eager alongside would double
+                # the footprint and spill on small GPUs), then time eager.
+                t_graph = self._time_path(lambda: step.run(positions, cell_array))
+                # drop every reference before releasing, or the graph pool
+                # survives gc and its reserved blocks skew the eager timing
+                step = None
+                self._release_captured_step()
+                t_eager = self._time_path(self._eager_runner(
+                    topology, z, natoms, batch, want_stress, positions, cell_array))
+                keep = t_graph <= t_eager
+                self._graph_choice[key] = keep
+                self._graph_stats["auto_choice"] = (
+                    f"n={n_atoms} stress={want_stress} "
+                    f"graph={t_graph*1e3:.1f}ms eager={t_eager*1e3:.1f}ms -> "
+                    f"{'graph' if keep else 'eager'}")
+                if not keep:
+                    return None
+                # graph wins: capture again (one-off cost) and keep using it
+                step = CapturedStep(
+                    model=self.model, topology=topology, z=z, natoms=natoms,
+                    batch=batch, n_atoms=n_atoms, cutoff=self.config.cutoff,
+                    skin=self.skin, precision=self.precision,
+                    device=self.device, with_stress=want_stress,
+                    positions=positions, cell=cell_array,
+                )
+                self._captured_step = step
+                self._graph_stats["captures"] += 1
+        return step
+
+    def _eager_runner(self, topology, z, natoms, batch, want_stress,
+                      positions, cell_array):
+        cell = torch.tensor(cell_array, dtype=self.precision, device=self.device)
+
+        def eager_once():
+            with torch.enable_grad():
+                pos = torch.tensor(positions, dtype=self.precision,
+                                   device=self.device, requires_grad=True)
+                graph_data = graph_from_neighbor_topology(
+                    pos=pos, z=z, natoms=natoms, batch=batch,
+                    topology=topology, cell=cell, cutoff=self.config.cutoff,
+                    dtype=self.precision, compute_stress=want_stress)
+                self.model.forward_graph(
+                    graph_data, prefix="infer", compute_forces=True,
+                    compute_stress=want_stress)
+
+        return eager_once
+
+    def _time_path(self, fn, repeats=5):
+        import time as _time
+        fn()  # warmup
+        torch.cuda.synchronize(self.device)
+        samples = []
+        for _ in range(repeats):
+            t0 = _time.perf_counter()
+            fn()
+            torch.cuda.synchronize(self.device)
+            samples.append(_time.perf_counter() - t0)
+        return float(np.median(samples))
 
     def _prepare_atoms(self):
         if not self.atoms.pbc.any():
@@ -182,6 +358,12 @@ class AlphaNetCalculator(Calculator):
         properties = properties or ['energy']
         calc_atoms = self._prepare_atoms()
         needs_stress = 'stress' in properties
+        if self.sticky_stress:
+            if needs_stress:
+                self._stress_sticky = True
+            # sticky mode: keep producing E+F+S so the remaining property
+            # calls of this optimizer/NPT step are served from the cache
+            needs_stress = needs_stress or self._stress_sticky
         needs_forces = needs_stress or ('forces' in properties)
         grad_enabled = needs_forces or needs_stress
 
@@ -235,6 +417,14 @@ class AlphaNetCalculator(Calculator):
                     pos=pos,
                     natoms=natoms,
                 )
+                captured = self._graph_step_for(
+                    topology, needs_stress, z, natoms, batch, len(calc_atoms),
+                    positions_for_model, cell_array)
+                if captured is not None:
+                    energy, forces, stress = captured.run(
+                        positions_for_model, cell_array)
+                    self._graph_stats["replays"] += 1
+                    return self._store_results(energy, forces, stress)
                 graph_data = graph_from_neighbor_topology(
                     pos=pos,
                     z=z,
@@ -264,13 +454,17 @@ class AlphaNetCalculator(Calculator):
                     compute_stress=needs_stress,
                 )
         
-        # --- Store Results ---
+        self._store_results(energy, forces, stress)
+
+    def _store_results(self, energy, forces, stress):
+        """Copy model outputs into ASE results (device->host copies detach the
+        values from any static CUDA-graph buffers before the next replay)."""
         self.results['energy'] = energy.detach().cpu().item()
-        self.results['free_energy'] = self.results['energy']  
-        
+        self.results['free_energy'] = self.results['energy']
+
         if forces is not None:
             self.results['forces'] = forces.detach().cpu().numpy()
-        
+
         if stress is not None:
             # Convert the model's 3x3 stress tensor to ASE's Voigt notation (6-element vector)
             stress_matrix = stress.detach().cpu().numpy()

--- a/alphanet/infer/calc.py
+++ b/alphanet/infer/calc.py
@@ -31,6 +31,7 @@ class AlphaNetCalculator(Calculator):
         skin=0.5,
         use_cuda_graph=None,
         sticky_stress=True,
+        use_fused_ops=None,
         **kwargs,
     ):
         """
@@ -59,6 +60,10 @@ class AlphaNetCalculator(Calculator):
                 step costs one forward+backward instead of ~2.5. Pure-MD
                 runs that never ask for stress are unaffected. Call
                 reset_neighbor_cache() to clear the mode.
+            use_fused_ops (bool | None): Use the fused Triton kernels
+                (inference-only, fp32+CUDA). None (default) enables them
+                automatically when Triton and a CUDA device are available;
+                unsupported configurations silently use the reference path.
             **kwargs: Additional arguments for the base ASE Calculator.
         """
         Calculator.__init__(self, **kwargs)
@@ -114,6 +119,22 @@ class AlphaNetCalculator(Calculator):
         # forward+backward per step. reset_neighbor_cache() clears it.
         self.sticky_stress = bool(sticky_stress)
         self._stress_sticky = False
+
+        # --- fused Triton ops (inference-only, fp32+CUDA) ---
+        if use_fused_ops is None:
+            try:
+                from alphanet import ops as _ops
+                use_fused_ops = (_ops.is_available()
+                                 and self.device.type == "cuda"
+                                 and self.precision == torch.float32)
+            except Exception:
+                use_fused_ops = False
+        inner_model = getattr(self.model, "model", None)
+        if inner_model is not None:
+            inner_model.use_fused_ops = bool(use_fused_ops)
+            for message_layer in getattr(inner_model, "message_layers", []):
+                message_layer.use_fused_ops = bool(use_fused_ops)
+        self.use_fused_ops = bool(use_fused_ops)
 
     @property
     def neighbor_cache_stats(self):

--- a/alphanet/infer/calc.py
+++ b/alphanet/infer/calc.py
@@ -108,6 +108,11 @@ class AlphaNetCalculator(Calculator):
         self._graph_auto = use_cuda_graph is None
         use_graph = True if use_cuda_graph is None else bool(use_cuda_graph)
         self.use_cuda_graph = use_graph and self.device.type == "cuda"
+        if (self.use_cuda_graph and not self._graph_auto
+                and getattr(config, "reduce_mode", "sum") != "sum"):
+            warnings.warn(
+                "use_cuda_graph=True ignored: the static-shape (masked) mode "
+                "is only exact for reduce_mode='sum'; using the eager path.")
         self._captured_step = None
         self._graph_disabled = False
         self._graph_choice = {}  # (n_atoms, with_stress) -> bool (auto mode)
@@ -172,7 +177,10 @@ class AlphaNetCalculator(Calculator):
         """Return a ready CapturedStep for this topology/request, or None to
         use the eager path. Handles (re)capture, cheap topology refresh and
         (in auto mode) the one-off replay-vs-eager timing decision."""
-        if not self.use_cuda_graph or self._graph_disabled or self.skin <= 0.0:
+        if (not self.use_cuda_graph or self._graph_disabled or self.skin <= 0.0
+                or getattr(self.config, "reduce_mode", "sum") != "sum"):
+            # Masked static shapes zero out-of-cutoff messages, which is only
+            # equivalent to hard edge filtering under sum aggregation.
             return None
         # needs_stress already reflects the sticky policy applied in
         # calculate(); a capture therefore keeps serving the whole E/F/S
@@ -248,6 +256,7 @@ class AlphaNetCalculator(Calculator):
                 )
                 self._captured_step = step
                 self._graph_stats["captures"] += 1
+        step.refresh_z(z)
         return step
 
     def _eager_runner(self, topology, z, natoms, batch, want_stress,

--- a/alphanet/infer/cuda_graph.py
+++ b/alphanet/infer/cuda_graph.py
@@ -1,0 +1,149 @@
+"""Whole-step CUDA Graph capture for AlphaNet ASE inference.
+
+A replayed step executes the entire edge-geometry -> forward -> autograd
+backward kernel sequence with a single graph launch, eliminating per-kernel
+launch latency and eager-autograd Python overhead (the dominant cost for
+small/medium systems).
+
+Design points:
+- Static shapes come from the masked edge mode (``static_shapes=True`` in
+  ``graph_from_neighbor_topology``): every cached edge (cutoff+skin) is kept
+  and out-of-cutoff edges are zeroed by ``edge_mask`` — mathematically
+  equivalent to hard filtering.
+- The edge buffers are over-allocated (``capacity_factor``) and padded with
+  self-edges carrying a huge cell offset, so their distance is far beyond the
+  cutoff: they are masked to exactly zero and produce no NaNs. A neighbor-list
+  rebuild therefore only refreshes the static buffers (the captured kernels
+  read the new indices on the next replay) — no recapture. Recapture happens
+  only when the edge count outgrows the capacity, the atom count changes, or
+  the stress mode changes.
+- ``torch.autograd.grad`` is captured inside the graph (official PyTorch
+  pattern: warmup iterations on a side stream, then capture); forces/stress
+  land in static output tensors.
+"""
+import numpy as np
+import torch
+
+from alphanet.models.graph import NeighborTopology, graph_from_neighbor_topology
+
+# Padding edges are (0, 0) self-pairs shifted by this many cells along the
+# first lattice vector: for any physically meaningful cell (|a1| > 0.5 A)
+# the padded distance is far beyond cutoff + skin, so the edge mask zeroes
+# them exactly and every edge quantity stays finite.
+_PAD_SHIFT = 16
+
+
+class CapturedStep:
+    """One CUDA graph per (topology window capacity, stress mode)."""
+
+    def __init__(self, model, topology, z, natoms, batch, n_atoms, cutoff,
+                 skin, precision, device, with_stress, pool=None,
+                 capacity_factor=1.1, warmup=3, positions=None, cell=None):
+        self.model = model
+        self.with_stress = with_stress
+        self.n_atoms = n_atoms
+        self.cutoff = float(cutoff)
+        self.skin = float(skin)
+        self.precision = precision
+        self.device = device
+        self.topology_ref = None
+
+        n_edges = int(topology.edge_index.shape[1])
+        self.capacity = max(int(np.ceil(n_edges * capacity_factor)), n_edges + 8)
+
+        # --- static buffers (inputs the captured kernels read) ---
+        self.pos_in = torch.zeros(n_atoms, 3, dtype=precision, device=device,
+                                  requires_grad=True)
+        self.cell_in = torch.zeros(3, 3, dtype=precision, device=device)
+        self._edge_index = torch.zeros(2, self.capacity, dtype=torch.long,
+                                       device=device)
+        self._cell_offsets = torch.zeros(self.capacity, 3, dtype=torch.int32,
+                                         device=device)
+        self._z = z.detach().clone()
+        self._natoms = natoms.detach().clone()
+        self._batch = batch.detach().clone()
+        self._pos_host = torch.empty(n_atoms, 3, dtype=precision).pin_memory()
+        self._cell_host = torch.empty(3, 3, dtype=precision).pin_memory()
+
+        self._static_topology = NeighborTopology(
+            edge_index=self._edge_index,
+            cell_offsets=self._cell_offsets,
+            neighbors=topology.neighbors,
+            reference_positions=topology.reference_positions,
+            reference_cell=topology.reference_cell,
+            cutoff=self.cutoff,
+            skin=self.skin,
+        )
+        self.update_topology(topology)
+        # Preload real inputs so warmup/capture run on physical values
+        # (kernels recorded are value-independent, but this keeps warmup free
+        # of NaN propagation from all-zero positions and makes any subsequent
+        # timing representative).
+        if positions is not None and cell is not None:
+            self._load_inputs(positions, cell)
+
+        def _run():
+            with torch.enable_grad():
+                data = graph_from_neighbor_topology(
+                    pos=self.pos_in, z=self._z, natoms=self._natoms,
+                    batch=self._batch, topology=self._static_topology,
+                    cell=self.cell_in, cutoff=self.cutoff, dtype=self.precision,
+                    compute_stress=self.with_stress, static_shapes=True)
+                return self.model.forward_graph(
+                    data, prefix="infer", compute_forces=True,
+                    compute_stress=self.with_stress)
+
+        # warmup on a side stream: cuBLAS workspaces, allocator, autograd
+        side = torch.cuda.Stream(device=device)
+        side.wait_stream(torch.cuda.current_stream(device))
+        with torch.cuda.stream(side):
+            for _ in range(warmup):
+                _run()
+        torch.cuda.current_stream(device).wait_stream(side)
+        torch.cuda.synchronize(device)
+        # Release the warmup's cached blocks back to the driver: the capture
+        # pool cannot reuse the regular allocator's cache, and on large
+        # systems the leftover reservation fragments the device enough to
+        # OOM the capture itself.
+        torch.cuda.empty_cache()
+
+        self.graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self.graph, pool=pool):
+            self.energy, self.forces, self.stress = _run()
+        self.pool = self.graph.pool()
+
+    def update_topology(self, topology) -> bool:
+        """Refresh the static edge buffers after a neighbor-list rebuild.
+
+        Returns False when the new edge count exceeds the captured capacity
+        (caller must recapture). No recapture is needed otherwise: the
+        captured gather/scatter kernels read these buffers at replay time.
+        """
+        n_edges = int(topology.edge_index.shape[1])
+        if n_edges > self.capacity or int(topology.edge_index.max().item() if n_edges else 0) >= self.n_atoms:
+            return False
+        with torch.no_grad():
+            self._edge_index[:, :n_edges] = topology.edge_index
+            self._edge_index[:, n_edges:] = 0
+            self._cell_offsets[:n_edges] = topology.cell_offsets
+            self._cell_offsets[n_edges:] = 0
+            self._cell_offsets[n_edges:, 0] = _PAD_SHIFT
+        self.topology_ref = topology
+        return True
+
+    def _load_inputs(self, positions: np.ndarray, cell: np.ndarray):
+        self._pos_host.copy_(torch.from_numpy(np.ascontiguousarray(positions)))
+        self._cell_host.copy_(torch.from_numpy(np.ascontiguousarray(cell)))
+        with torch.no_grad():
+            self.pos_in.copy_(self._pos_host, non_blocking=True)
+            self.cell_in.copy_(self._cell_host, non_blocking=True)
+
+    def run(self, positions: np.ndarray, cell: np.ndarray):
+        """Copy inputs into the static buffers, replay, return static outputs.
+
+        The returned tensors are overwritten by the next replay — consume
+        (``.cpu()``/``.item()``) before calling ``run`` again.
+        """
+        self._load_inputs(positions, cell)
+        self.graph.replay()
+        return self.energy, self.forces, self.stress

--- a/alphanet/infer/cuda_graph.py
+++ b/alphanet/infer/cuda_graph.py
@@ -131,6 +131,14 @@ class CapturedStep:
         self.topology_ref = topology
         return True
 
+    def refresh_z(self, z: torch.Tensor) -> None:
+        """Refresh the static atomic-number buffer read by the captured
+        kernels: species can change while the atom count stays the same
+        (composition screening, MC swaps), which rebuilds the topology but
+        does not trigger a recapture."""
+        with torch.no_grad():
+            self._z.copy_(z)
+
     def _load_inputs(self, positions: np.ndarray, cell: np.ndarray):
         self._pos_host.copy_(torch.from_numpy(np.ascontiguousarray(positions)))
         self._cell_host.copy_(torch.from_numpy(np.ascontiguousarray(cell)))

--- a/alphanet/models/alphanet.py
+++ b/alphanet/models/alphanet.py
@@ -10,6 +10,13 @@ from torch_geometric.nn.conv import MessagePassing
 from alphanet.models.graph import GraphData
 import numpy as np
 
+try:  # fused Triton ops (phase 3); reference path remains the fallback
+    from alphanet import ops as _fused_ops
+    if not _fused_ops.is_available():
+        _fused_ops = None
+except Exception:
+    _fused_ops = None
+
 
 def scatter(src: torch.Tensor, index: torch.Tensor, dim: int = -1, 
             out: Optional[torch.Tensor] = None, dim_size: Optional[int] = None, 
@@ -244,16 +251,26 @@ class EquiMessagePassing(MessagePassing):
         rbfh = self.rbf_proj(edge_rbf)
         weight = self.dir_proj(weight)
         rbfh = rbfh * weight
-        
-        dx, dvec = self.propagate(
-            edge_index,
-            xh=xh,
-            vec=vec,
-            rbfh_ij=rbfh,
-            r_ij=edge_vector,
-            edge_mask=edge_mask,
-            size=None,
-        )
+
+        if (getattr(self, "use_fused_ops", False) and _fused_ops is not None
+                and not self.training and xh.is_cuda
+                and xh.dtype == torch.float32 and self.reduce_mode == "sum"):
+            # Fused message+aggregate (inference): per-edge MPS contraction,
+            # rank-1 dia, fc_mps, atan2 and the vector message all live in
+            # one kernel that accumulates straight into the node outputs —
+            # no [E,3H] gathers or [E,3,H] message tensors are materialized.
+            dx, dvec = _fused_ops.fused_equi_message(
+                self, xh, vec, rbfh, edge_vector, edge_index, edge_mask)
+        else:
+            dx, dvec = self.propagate(
+                edge_index,
+                xh=xh,
+                vec=vec,
+                rbfh_ij=rbfh,
+                r_ij=edge_vector,
+                edge_mask=edge_mask,
+                size=None,
+            )
         
         if self.has_norm_before_flag:
             dx = self.dx_layer_norm(dx)
@@ -400,6 +417,11 @@ class AlphaNet(nn.Module):
         self.compute_forces = config.compute_forces
         self.compute_stress = config.compute_stress
         
+        # Inference-only fused Triton kernels (fp32+CUDA). Off by default so
+        # training and TorchScript are untouched; AlphaNetCalculator enables
+        # it when the environment supports it.
+        self.use_fused_ops = False
+
         self.z_emb_ln = nn.LayerNorm(config.hidden_channels, elementwise_affine=False)
         self.z_emb = Embedding(95, config.hidden_channels)
         self.kernel1 = torch.nn.Parameter(torch.randn((config.hidden_channels, self.chi1 * 2), device=self.device))
@@ -538,22 +560,32 @@ class AlphaNet(nn.Module):
 
         S_i_j = self.S_vector(s, edge_diff.unsqueeze(-1), edge_index, radial_hidden)
         
-        # Scalarization via bmm: out[e,f,h] = sum_d edge_frame[e,d,f] * S[e,d,h].
-        # Math-equivalent to the broadcast+sum form but never materializes the
-        # [E,3,3,H] product tensor; the frame-axis-1 square is written without
-        # in-place aliasing (cleaner for autograd).
-        frame_t = edge_frame.transpose(1, 2)
-        scalrization1 = torch.bmm(frame_t, S_i_j[i])
-        scalrization2 = torch.bmm(frame_t, S_i_j[j])
-        s1_0, s1_1, s1_2 = scalrization1.unbind(dim=1)
-        scalrization1 = torch.stack((s1_0, s1_1 * s1_1, s1_2), dim=1)
-        s2_0, s2_1, s2_2 = scalrization2.unbind(dim=1)
-        scalrization2 = torch.stack((s2_0, s2_1 * s2_1, s2_2), dim=1)
-        
-        scalar3 = (self.lin(torch.permute(scalrization1, (0, 2, 1))) + 
-                  torch.permute(scalrization1, (0, 2, 1))[:, :, 0].unsqueeze(2)).squeeze(-1) / math.sqrt(self.hidden_channels)
-        scalar4 = (self.lin(torch.permute(scalrization2, (0, 2, 1))) + 
-                  torch.permute(scalrization2, (0, 2, 1))[:, :, 0].unsqueeze(2)).squeeze(-1) / math.sqrt(self.hidden_channels)
+        if (getattr(self, "use_fused_ops", False) and _fused_ops is not None
+                and not self.training
+                and edge_frame.is_cuda and edge_frame.dtype == torch.float32):
+            # Fused Triton kernel: frame projection + square + 3->H/4->1 MLP
+            # entirely in registers — eliminates the two [E,H,H/4] hidden
+            # blocks (the model's largest allocation) and their autograd
+            # copies. Math-identical to the reference block below.
+            scalar3, scalar4 = _fused_ops.fused_scalarization_mlp(
+                S_i_j, edge_frame, i, j, self.lin, self.hidden_channels)
+        else:
+            # Scalarization via bmm: out[e,f,h] = sum_d edge_frame[e,d,f] * S[e,d,h].
+            # Math-equivalent to the broadcast+sum form but never materializes the
+            # [E,3,3,H] product tensor; the frame-axis-1 square is written without
+            # in-place aliasing (cleaner for autograd).
+            frame_t = edge_frame.transpose(1, 2)
+            scalrization1 = torch.bmm(frame_t, S_i_j[i])
+            scalrization2 = torch.bmm(frame_t, S_i_j[j])
+            s1_0, s1_1, s1_2 = scalrization1.unbind(dim=1)
+            scalrization1 = torch.stack((s1_0, s1_1 * s1_1, s1_2), dim=1)
+            s2_0, s2_1, s2_2 = scalrization2.unbind(dim=1)
+            scalrization2 = torch.stack((s2_0, s2_1 * s2_1, s2_2), dim=1)
+
+            scalar3 = (self.lin(torch.permute(scalrization1, (0, 2, 1))) +
+                      torch.permute(scalrization1, (0, 2, 1))[:, :, 0].unsqueeze(2)).squeeze(-1) / math.sqrt(self.hidden_channels)
+            scalar4 = (self.lin(torch.permute(scalrization2, (0, 2, 1))) +
+                      torch.permute(scalrization2, (0, 2, 1))[:, :, 0].unsqueeze(2)).squeeze(-1) / math.sqrt(self.hidden_channels)
         
         edge_weight = torch.cat((scalar3, scalar4), dim=-1) * rbounds.unsqueeze(-1)
         edge_weight = torch.cat((edge_weight, radial_hidden, radial_emb), dim=-1)

--- a/alphanet/models/alphanet.py
+++ b/alphanet/models/alphanet.py
@@ -127,7 +127,8 @@ class S_vector(MessagePassing):
 
 class EquiMessagePassing(MessagePassing):
     propagate_type = {
-        'xh': Tensor, 'vec': Tensor, 'rbfh_ij': Tensor, 'r_ij': Tensor
+        'xh': Tensor, 'vec': Tensor, 'rbfh_ij': Tensor, 'r_ij': Tensor,
+        'edge_mask': Optional[Tensor]
     }
 
     def __init__(
@@ -228,7 +229,8 @@ class EquiMessagePassing(MessagePassing):
         edge_rbf: Tensor,
         weight: Tensor,
         edge_vector: Tensor,
-        rope: Optional[Tensor] = None
+        rope: Optional[Tensor] = None,
+        edge_mask: Optional[Tensor] = None
     ) -> Tuple[Tensor, Tensor, Tensor]:
         if rope is not None:
             # rope is a real tensor [N, hidden_channels]: first half cos(dx),
@@ -249,6 +251,7 @@ class EquiMessagePassing(MessagePassing):
             vec=vec,
             rbfh_ij=rbfh,
             r_ij=edge_vector,
+            edge_mask=edge_mask,
             size=None,
         )
         
@@ -267,7 +270,7 @@ class EquiMessagePassing(MessagePassing):
 
         return dx, dy, dvec
 
-    def message(self, xh_j, vec_j, rbfh_ij, r_ij):
+    def message(self, xh_j, vec_j, rbfh_ij, r_ij, edge_mask: Optional[Tensor] = None):
         x, xh2, xh3 = torch.split(xh_j * rbfh_ij, self.hidden_channels, dim=-1)
         xh2 = xh2 * self.inv_sqrt_3
 
@@ -305,6 +308,13 @@ class EquiMessagePassing(MessagePassing):
         agg = torch.cat([kernel, x], dim=-1)
         vec = vec_j * xh2.unsqueeze(1) + xh3.unsqueeze(1) * r_ij.unsqueeze(2)
         vec = vec * self.inv_sqrt_h
+
+        if edge_mask is not None:
+            # Static-shape mode: rbf_proj/dir_proj/scale/fc_mps carry biases,
+            # so out-of-cutoff edges produce nonzero messages; zero them here
+            # (exactly reproduces the hard edge filtering).
+            agg = agg * edge_mask
+            vec = vec * edge_mask.unsqueeze(-1)
 
         return agg, vec
 
@@ -489,11 +499,19 @@ class AlphaNet(nn.Module):
         edge_index = data.edge_index
         vecs = data.edge_vec
         
+        edge_mask = data.edge_mask
+
         dist = torch.linalg.norm(vecs, dim=1)
         z_emb = self.z_emb_ln(self.z_emb(z))
         radial_emb = self.radial_emb(dist)
         radial_hidden = self.radial_lin(radial_emb)
         rbounds = 0.5 * (torch.cos(dist * self.pi / self.cutoff) + 1.0)
+        if edge_mask is not None:
+            # Static-shape mode: beyond the cutoff the cosine argument passes
+            # pi and rbounds would go negative; the mask restores the exact
+            # hard-filtered value (zero). NeighborEmb/S_vector messages are
+            # proportional to radial_hidden and therefore vanish automatically.
+            rbounds = rbounds * edge_mask.squeeze(-1)
         radial_hidden = rbounds.unsqueeze(-1) * radial_hidden
 
         s = self.neighbor_emb(z, z_emb, edge_index, radial_hidden)
@@ -504,7 +522,16 @@ class AlphaNet(nn.Module):
         edge_diff = vecs
         edge_diff = edge_diff / (dist.unsqueeze(1) + self.eps)
         
-        edge_vec_mean = scatter(vecs, i, reduce='mean', dim=0) 
+        if edge_mask is not None:
+            # Masked mean over valid edges only — skin edges must not pollute
+            # the local frames. dim_size is passed explicitly so no GPU->CPU
+            # sync happens (CUDA-graph capturable); rows beyond max(i) are
+            # zero and never gathered.
+            vec_sum = scatter(vecs * edge_mask, i, dim=0, dim_size=s.size(0), reduce='sum')
+            vec_cnt = scatter(edge_mask, i, dim=0, dim_size=s.size(0), reduce='sum').clamp(min=1.0)
+            edge_vec_mean = vec_sum / vec_cnt
+        else:
+            edge_vec_mean = scatter(vecs, i, reduce='mean', dim=0)
         edge_cross = torch.cross(vecs, edge_vec_mean[i])
         edge_vertical = torch.cross(edge_diff, edge_cross)
         edge_frame = torch.cat((edge_diff.unsqueeze(-1), edge_cross.unsqueeze(-1), edge_vertical.unsqueeze(-1)), dim=-1)
@@ -539,7 +566,7 @@ class AlphaNet(nn.Module):
 
         rope: Optional[Tensor] = None
         for id, (message_layer, fte) in enumerate(zip(self.message_layers, self.FTEs)):
-            rope, ds, dvec = message_layer(s, vec, edge_index, radial_emb, edge_weight, edge_diff, rope)
+            rope, ds, dvec = message_layer(s, vec, edge_index, radial_emb, edge_weight, edge_diff, rope, edge_mask)
 
             s = s + ds
             vec = vec + dvec
@@ -571,7 +598,10 @@ class AlphaNet(nn.Module):
             raise ValueError(f"Unexpected shape of s: {s.shape}")
 
         atom_energy = s.squeeze(-1) if s.dim() == 2 and s.size(-1) == 1 else s
-        total_energy = scatter(atom_energy, batch, dim=0, reduce=self.readout).squeeze()
+        # dim_size from natoms metadata (== max(batch)+1) avoids the implicit
+        # index.max() GPU->CPU sync so the step stays CUDA-graph capturable.
+        total_energy = scatter(atom_energy, batch, dim=0,
+                               dim_size=int(data.natoms.numel()), reduce=self.readout).squeeze()
         
         if self.use_sigmoid:
             if return_atom_energy:

--- a/alphanet/models/alphanet.py
+++ b/alphanet/models/alphanet.py
@@ -231,10 +231,12 @@ class EquiMessagePassing(MessagePassing):
         rope: Optional[Tensor] = None
     ) -> Tuple[Tensor, Tensor, Tensor]:
         if rope is not None:
-            real, imag = torch.split(x, [self.hidden_channels // 2, self.hidden_channels // 2], dim=-1)
-            dy_pre = torch.complex(real=real, imag=imag)
-            dy_pre = dy_pre * rope
-            x = torch.cat([dy_pre.real, dy_pre.imag], dim=-1)
+            # rope is a real tensor [N, hidden_channels]: first half cos(dx),
+            # second half sin(dx). Complex rotation (x_r + i x_i)(c + i s)
+            # carried out in real arithmetic (math-equivalent).
+            rc, rs = torch.split(rope, [self.hidden_channels // 2, self.hidden_channels // 2], dim=-1)
+            xr, xi = torch.split(x, [self.hidden_channels // 2, self.hidden_channels // 2], dim=-1)
+            x = torch.cat([xr * rc - xi * rs, xr * rs + xi * rc], dim=-1)
             
         xh = self.x_proj(self.x_layernorm(x))
         rbfh = self.rbf_proj(edge_rbf)
@@ -259,38 +261,47 @@ class EquiMessagePassing(MessagePassing):
             dx = self.dx_layer_norm(dx)
 
         dx = self.scale2(dx)
-        dx = torch.complex(torch.cos(dx), torch.sin(dx))
-        
+        # next-layer rope as a real tensor [N, hidden_channels]:
+        # equivalent to complex(cos(dx), sin(dx))
+        dx = torch.cat([torch.cos(dx), torch.sin(dx)], dim=-1)
+
         return dx, dy, dvec
 
     def message(self, xh_j, vec_j, rbfh_ij, r_ij):
         x, xh2, xh3 = torch.split(xh_j * rbfh_ij, self.hidden_channels, dim=-1)
         xh2 = xh2 * self.inv_sqrt_3
-        
-        real, imagine = torch.split(self.scale(x), self.hidden_channels_chi, dim=-1)
-        real = real.reshape(x.shape[0], self.head, (self.hidden_channels_chi) // self.head)
-        imagine = imagine.reshape(x.shape[0], self.head, (self.hidden_channels_chi) // self.head)
+
+        # MPS contraction in real arithmetic (math-equivalent rewrite).
+        # Original: conv[e,k] = sum_{j,l} cat([ones, phi])[e,j,l] * K[j,l,k]
+        # with K = complex(kernel_real, kernel_imag)/sqrt(H/head) of shape
+        # [head+1, C, chi2]. The ones row (j=0) contributes the constant bias
+        # sum_l K[0,l,k]; the remaining rows form a real/imag GEMM pair over
+        # the flattened (j,l) axis, so no [E, head+1, C, chi2] tensor is built.
+        C = self.hidden_channels_chi // self.head
+        qr, qi = torch.split(self.scale(x), self.hidden_channels_chi, dim=-1)
         if self.has_dropout_flag:
-            real = self.dropout(real)
-            imagine = self.dropout(imagine)
+            qr = self.dropout(qr)
+            qi = self.dropout(qi)
 
-        phi = torch.complex(real, imagine)
-        q = phi
-        a = torch.ones(q.shape[0], 1, (self.hidden_channels_chi) // self.head, device=q.device, dtype=self.complex_type)
-        kernel = (torch.complex(self.kernel_real, self.kernel_imag) / math.sqrt((self.hidden_channels) // self.head)).expand(q.shape[0], -1, -1, -1)
+        norm_factor = math.sqrt(self.hidden_channels // self.head)
+        Kr = (self.kernel_real / norm_factor).reshape(-1, self.chi2)
+        Ki = (self.kernel_imag / norm_factor).reshape(-1, self.chi2)
+        conv_r = torch.matmul(qr, Kr[C:]) - torch.matmul(qi, Ki[C:]) + Kr[:C].sum(0)
+        conv_i = torch.matmul(qr, Ki[C:]) + torch.matmul(qi, Kr[C:]) + Ki[:C].sum(0)
 
-        equation = 'ijl, ijlk->ik'
-        conv = torch.einsum(equation, torch.cat([a, q], dim=1), kernel.to(self.complex_type))
-        a = 1.0 * self.activation(self.diagonal(rbfh_ij))
-        b = a.unsqueeze(-1) * self.diachi1.unsqueeze(0).unsqueeze(0) + torch.ones(kernel.shape[0], self.chi2, self.chi1, device=rbfh_ij.device)
-        dia = self.dia(b)
-        
-        equation = 'ik,ikl->il'
-        kernel = torch.einsum(equation, conv, dia.to(self.complex_type))
-        kernel_real, kernel_imag = kernel.real, kernel.imag
-        kernel_real, kernel_imag = self.fc_mps(kernel_real), self.fc_mps(kernel_imag)
-        kernel = torch.angle(torch.complex(kernel_real, kernel_imag))
-        
+        # dia(b) with b[e,k,l] = a[e,k]*diachi1[l] + 1 has an exact rank-1
+        # form: dia[e,k,m] = a[e,k]*u[m] + v[m], u = W@diachi1, v = W@1 + bias
+        # (u, v are edge-independent), so einsum('ik,ikl->il', conv, dia)
+        # collapses to two per-edge reductions and an outer product.
+        a = self.activation(self.diagonal(rbfh_ij))
+        u = torch.matmul(self.dia.weight, self.diachi1)
+        v = self.dia.weight.sum(1) + self.dia.bias
+        ker_r = (conv_r * a).sum(-1, keepdim=True) * u + conv_r.sum(-1, keepdim=True) * v
+        ker_i = (conv_i * a).sum(-1, keepdim=True) * u + conv_i.sum(-1, keepdim=True) * v
+
+        # angle(complex(fc(re), fc(im))) == atan2(fc(im), fc(re))
+        kernel = torch.atan2(self.fc_mps(ker_i), self.fc_mps(ker_r))
+
         agg = torch.cat([kernel, x], dim=-1)
         vec = vec_j * xh2.unsqueeze(1) + xh3.unsqueeze(1) * r_ij.unsqueeze(2)
         vec = vec * self.inv_sqrt_h
@@ -500,10 +511,17 @@ class AlphaNet(nn.Module):
 
         S_i_j = self.S_vector(s, edge_diff.unsqueeze(-1), edge_index, radial_hidden)
         
-        scalrization1 = torch.sum(S_i_j[i].unsqueeze(2) * edge_frame.unsqueeze(-1), dim=1)
-        scalrization2 = torch.sum(S_i_j[j].unsqueeze(2) * edge_frame.unsqueeze(-1), dim=1)
-        scalrization1[:, 1, :] = torch.square(scalrization1[:, 1, :].clone())
-        scalrization2[:, 1, :] = torch.square(scalrization2[:, 1, :].clone())
+        # Scalarization via bmm: out[e,f,h] = sum_d edge_frame[e,d,f] * S[e,d,h].
+        # Math-equivalent to the broadcast+sum form but never materializes the
+        # [E,3,3,H] product tensor; the frame-axis-1 square is written without
+        # in-place aliasing (cleaner for autograd).
+        frame_t = edge_frame.transpose(1, 2)
+        scalrization1 = torch.bmm(frame_t, S_i_j[i])
+        scalrization2 = torch.bmm(frame_t, S_i_j[j])
+        s1_0, s1_1, s1_2 = scalrization1.unbind(dim=1)
+        scalrization1 = torch.stack((s1_0, s1_1 * s1_1, s1_2), dim=1)
+        s2_0, s2_1, s2_2 = scalrization2.unbind(dim=1)
+        scalrization2 = torch.stack((s2_0, s2_1 * s2_1, s2_2), dim=1)
         
         scalar3 = (self.lin(torch.permute(scalrization1, (0, 2, 1))) + 
                   torch.permute(scalrization1, (0, 2, 1))[:, :, 0].unsqueeze(2)).squeeze(-1) / math.sqrt(self.hidden_channels)
@@ -513,33 +531,37 @@ class AlphaNet(nn.Module):
         edge_weight = torch.cat((scalar3, scalar4), dim=-1) * rbounds.unsqueeze(-1)
         edge_weight = torch.cat((edge_weight, radial_hidden, radial_emb), dim=-1)
         
-        equation = 'ik,bi->bk'
-        quantum = torch.einsum(equation, self.kernel1, z_emb)
-        real, imagine = torch.split(quantum, self.chi1, dim=-1)
-        quantum = torch.complex(real, imagine)
+        # Quantum state kept as a (q_real, q_imag) pair of real tensors —
+        # math-equivalent to the original complex representation, avoids
+        # complex GEMMs on a real-valued s (whose imaginary part is zero).
+        quantum = torch.matmul(z_emb, self.kernel1)
+        q_real, q_imag = torch.split(quantum, self.chi1, dim=-1)
 
-        rope = None
+        rope: Optional[Tensor] = None
         for id, (message_layer, fte) in enumerate(zip(self.message_layers, self.FTEs)):
-            if rope is None:
-                rope, ds, dvec = message_layer(s, vec, edge_index, radial_emb, edge_weight, edge_diff, None)
-            else:
-                rope, ds, dvec = message_layer(s, vec, edge_index, radial_emb, edge_weight, edge_diff, rope)
-            
+            rope, ds, dvec = message_layer(s, vec, edge_index, radial_emb, edge_weight, edge_diff, rope)
+
             s = s + ds
             vec = vec + dvec
-            
-            kernel_real = self.kernels_real[id]
-            kernel_imag = self.kernels_imag[id]
-            equation = 'ikl,bi,bl->bk'
-            kerneli = torch.complex(kernel_real, kernel_imag)
-            quantum = torch.einsum(equation, kerneli, s.to(self.complex_type), quantum)
-            quantum = quantum / (self.eps + quantum.abs().to(self.complex_type))
-            
+
+            # new_q[b,k] = sum_{i,l} K[i,k,l] * s[b,i] * q[b,l] with
+            # K = kernels_real[id] + i*kernels_imag[id]: contract s first
+            # (two real GEMMs), then a batched mat-vec in real/imag parts.
+            Mr = torch.matmul(s, self.kernels_real[id].reshape(self.hidden_channels, -1)).view(-1, self.chi1, self.chi1)
+            Mi = torch.matmul(s, self.kernels_imag[id].reshape(self.hidden_channels, -1)).view(-1, self.chi1, self.chi1)
+            nr = torch.bmm(Mr, q_real.unsqueeze(-1)) - torch.bmm(Mi, q_imag.unsqueeze(-1))
+            ni = torch.bmm(Mr, q_imag.unsqueeze(-1)) + torch.bmm(Mi, q_real.unsqueeze(-1))
+            nr = nr.squeeze(-1)
+            ni = ni.squeeze(-1)
+            qnorm = torch.sqrt(nr * nr + ni * ni)
+            q_real = nr / (self.eps + qnorm)
+            q_imag = ni / (self.eps + qnorm)
+
             ds, dvec = fte(s, vec)
             s = s + ds
             vec = vec + dvec
 
-        s = self.last_layer(s) + self.last_layer_quantum(torch.cat([quantum.real, quantum.imag], dim=-1)) / self.chi1
+        s = self.last_layer(s) + self.last_layer_quantum(torch.cat([q_real, q_imag], dim=-1)) / self.chi1
         
         if s.dim() == 2:
             s = (self.a[z].unsqueeze(1) * s + self.b[z].unsqueeze(1))

--- a/alphanet/models/graph.py
+++ b/alphanet/models/graph.py
@@ -20,6 +20,10 @@ class GraphData(NamedTuple):
     cell_offsets: Tensor = None
     displacement: Optional[Tensor] = None
     pbc: Optional[Tensor] = None
+    # Static-shape mode (CUDA-graph friendly): edge_index keeps every cached
+    # edge (cutoff+skin) and edge_mask[e] = 1.0 iff 0 < dist <= cutoff.
+    # None means edges were hard-filtered as before.
+    edge_mask: Optional[Tensor] = None
 
 
 @dataclass
@@ -175,7 +179,8 @@ def _update_edge_geometry(
     cell_offsets: Tensor,
     precision: torch.dtype = torch.float32,
     cutoff: Optional[float] = None,
-) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
+    static_shapes: bool = False,
+) -> Tuple[Tensor, Tensor, Tensor, Tensor, Optional[Tensor]]:
     row = edge_index[0]
     col = edge_index[1]
     edge_batch = batch[col]
@@ -191,11 +196,18 @@ def _update_edge_geometry(
     valid_mask = distances > 0
     if cutoff is not None:
         valid_mask = torch.logical_and(valid_mask, distances <= cutoff)
+    if static_shapes:
+        # Keep every cached edge so tensor shapes stay constant within a
+        # topology window (CUDA-graph capturable); validity is expressed as a
+        # multiplicative mask instead of index filtering. Mathematically
+        # equivalent: out-of-cutoff edge contributions are zeroed in the model.
+        edge_mask = valid_mask.to(precision).unsqueeze(-1)
+        return edge_index, cell_offsets, distances, distance_vectors, edge_mask
     edge_index = edge_index[:, valid_mask]
     cell_offsets = cell_offsets[valid_mask]
     distances = distances[valid_mask]
     distance_vectors = distance_vectors[valid_mask]
-    return edge_index, cell_offsets, distances, distance_vectors
+    return edge_index, cell_offsets, distances, distance_vectors, None
 
 
 def graph_from_neighbor_topology(
@@ -209,6 +221,7 @@ def graph_from_neighbor_topology(
     cutoff: Optional[float] = None,
     dtype: torch.dtype = torch.float32,
     compute_stress: bool = False,
+    static_shapes: bool = False,
 ) -> GraphData:
     precision = dtype
     pos = pos.to(precision)
@@ -225,7 +238,7 @@ def graph_from_neighbor_topology(
             pos, cell, num_graphs=int(natoms.numel()), batch=batch
         )
         cell = check_and_reshape_cell(cell)
-    edge_index, cell_offsets, dist, vecs = _update_edge_geometry(
+    edge_index, cell_offsets, dist, vecs, edge_mask = _update_edge_geometry(
         pos=pos,
         batch=batch,
         edge_index=topology.edge_index,
@@ -233,6 +246,7 @@ def graph_from_neighbor_topology(
         cell_offsets=topology.cell_offsets,
         precision=precision,
         cutoff=topology.cutoff if cutoff is None else cutoff,
+        static_shapes=static_shapes,
     )
     return GraphData(
         pos=pos,
@@ -245,6 +259,7 @@ def graph_from_neighbor_topology(
         cell=cell,
         cell_offsets=cell_offsets,
         displacement=displacement,
+        edge_mask=edge_mask,
     )
 
 

--- a/alphanet/models/graph.py
+++ b/alphanet/models/graph.py
@@ -208,11 +208,23 @@ def graph_from_neighbor_topology(
     displacement: Optional[Tensor] = None,
     cutoff: Optional[float] = None,
     dtype: torch.dtype = torch.float32,
+    compute_stress: bool = False,
 ) -> GraphData:
     precision = dtype
     pos = pos.to(precision)
     z = z.long()
     cell = check_and_reshape_cell(cell)
+    if compute_stress and displacement is None:
+        # Inject the symmetric-displacement trick on top of the cached
+        # topology: the displacement tensor is numerically zero, so positions,
+        # cell and hence the cached neighbor list are unchanged; the edge
+        # geometry below is recomputed from the displaced pos/cell and is
+        # therefore differentiable w.r.t. the displacement (stress via
+        # autograd), exactly as in process_positions_and_edges.
+        pos, cell, displacement = get_symmetric_displacement(
+            pos, cell, num_graphs=int(natoms.numel()), batch=batch
+        )
+        cell = check_and_reshape_cell(cell)
     edge_index, cell_offsets, dist, vecs = _update_edge_geometry(
         pos=pos,
         batch=batch,

--- a/alphanet/ops/__init__.py
+++ b/alphanet/ops/__init__.py
@@ -1,0 +1,24 @@
+"""Fused Triton operators for AlphaNet inference (plan phase 3).
+
+Import is guarded: on machines without a CUDA device or without Triton the
+package degrades to ``is_available() == False`` and the model falls back to
+the reference (pure PyTorch) implementation, which remains the source of
+truth for training and for fp64.
+"""
+import torch
+
+try:
+    import triton  # noqa: F401
+    _HAS_TRITON = True
+except Exception:  # pragma: no cover - environment without triton
+    _HAS_TRITON = False
+
+
+def is_available() -> bool:
+    """Fused ops run on CUDA + fp32 only (fp64 falls back to reference)."""
+    return _HAS_TRITON and torch.cuda.is_available()
+
+
+if _HAS_TRITON:
+    from alphanet.ops.scalarization import fused_scalarization_mlp  # noqa: F401
+    from alphanet.ops.message import fused_equi_message  # noqa: F401

--- a/alphanet/ops/message.py
+++ b/alphanet/ops/message.py
@@ -1,0 +1,309 @@
+"""Fused EquiMessagePassing message+aggregate (plan phase-3 operator A).
+
+Reference (EquiMessagePassing.message/aggregate, real-arithmetic form):
+    x1, xh2, xh3 = split(xh[j] * rbfh, H)          # per edge
+    (qr | qi)    = scale(x1)                       # edge GEMM, stays in cuBLAS
+    conv         = q @ K[C:] + bias(K[:C])         # complex via real pairs
+    ker          = (conv*a).sum() * u + conv.sum() * v      # rank-1 collapse
+    msg_kernel   = atan2(fc(ker_i), fc(ker_r))     # [E, chi1]
+    agg          = cat(msg_kernel, x1) * mask      # -> scatter_add -> dx
+    vec_msg      = (vec[j]*xh2/sqrt3 + xh3 (x) r_ij)/sqrt(H) * mask
+                                                    # -> scatter_add -> dvec
+
+The wrapper keeps the three cuBLAS GEMMs (scale, diagonal MLP) outside; the
+kernel fuses everything per edge in registers and accumulates straight into
+the node outputs, so the [E,3H] gathers, [E,3,H] vector messages and
+[E,chi1+H] message tensors (and their autograd copies) never exist.
+Backward recomputes the chain per edge and emits grads for the tensor
+inputs only (weights: inference-only, model gates on `not self.training`).
+
+fp32 + CUDA only.
+"""
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fwd_kernel(xh_ptr, vec_ptr, rbfh_ptr, x1_ptr, qr_ptr, qi_ptr, a_ptr,
+                r_ptr, mask_ptr, idx_i_ptr, idx_j_ptr,
+                Kr_ptr, Ki_ptr, u_ptr, v_ptr, fcw_ptr, fcb_ptr,
+                dx_ptr, dvec_ptr,
+                H, HCHI, CHI1, CHI2, C, inv_sqrt_3, inv_sqrt_h,
+                HAS_MASK: tl.constexpr,
+                BLOCK_H: tl.constexpr, BLOCK_HCHI: tl.constexpr,
+                BLOCK_C1: tl.constexpr, BLOCK_C2: tl.constexpr):
+    e = tl.program_id(0)
+    i = tl.load(idx_i_ptr + e)
+    j = tl.load(idx_j_ptr + e)
+    if HAS_MASK:
+        m = tl.load(mask_ptr + e)
+    else:
+        m = 1.0
+
+    # ---- MPS contraction: conv[k] = sum_c qr/qi[c] * K[C+c, k] + bias_k ----
+    c2 = tl.arange(0, BLOCK_C2)
+    c2m = c2 < CHI2
+    cc = tl.arange(0, BLOCK_HCHI)
+    ccm = cc < HCHI
+    qr = tl.load(qr_ptr + e * HCHI + cc, mask=ccm, other=0.0)
+    qi = tl.load(qi_ptr + e * HCHI + cc, mask=ccm, other=0.0)
+    # K rows: first C rows are the "ones" bias, then HCHI rows
+    kr_bias = tl.zeros([BLOCK_C2], dtype=tl.float32)
+    ki_bias = tl.zeros([BLOCK_C2], dtype=tl.float32)
+    for cidx in range(0, C):
+        kr_bias += tl.load(Kr_ptr + cidx * CHI2 + c2, mask=c2m, other=0.0)
+        ki_bias += tl.load(Ki_ptr + cidx * CHI2 + c2, mask=c2m, other=0.0)
+    Krm = tl.load(Kr_ptr + (C + cc[:, None]) * CHI2 + c2[None, :],
+                  mask=ccm[:, None] & c2m[None, :], other=0.0)
+    Kim = tl.load(Ki_ptr + (C + cc[:, None]) * CHI2 + c2[None, :],
+                  mask=ccm[:, None] & c2m[None, :], other=0.0)
+    conv_r = tl.sum(qr[:, None] * Krm - qi[:, None] * Kim, axis=0) + kr_bias
+    conv_i = tl.sum(qr[:, None] * Kim + qi[:, None] * Krm, axis=0) + ki_bias
+
+    # ---- rank-1 dia collapse + fc_mps + atan2 ----
+    a = tl.load(a_ptr + e * CHI2 + c2, mask=c2m, other=0.0)
+    ca_r = tl.sum(conv_r * a)
+    ca_i = tl.sum(conv_i * a)
+    cs_r = tl.sum(tl.where(c2m, conv_r, 0.0))
+    cs_i = tl.sum(tl.where(c2m, conv_i, 0.0))
+    c1 = tl.arange(0, BLOCK_C1)
+    c1m = c1 < CHI1
+    u = tl.load(u_ptr + c1, mask=c1m, other=0.0)
+    v = tl.load(v_ptr + c1, mask=c1m, other=0.0)
+    ker_r = ca_r * u + cs_r * v
+    ker_i = ca_i * u + cs_i * v
+    fcw = tl.load(fcw_ptr + c1[:, None] * CHI1 + c1[None, :],
+                  mask=c1m[:, None] & c1m[None, :], other=0.0)
+    fcb = tl.load(fcb_ptr + c1, mask=c1m, other=0.0)
+    fr = tl.sum(fcw * ker_r[None, :], axis=1) + fcb
+    fi = tl.sum(fcw * ker_i[None, :], axis=1) + fcb
+    msg_kernel = tl.math.atan2(fi, fr) * m
+
+    # ---- accumulate dx[i] = [msg_kernel, x1] ----
+    tl.atomic_add(dx_ptr + i * (CHI1 + H) + c1, msg_kernel, mask=c1m)
+    h = tl.arange(0, BLOCK_H)
+    hm = h < H
+    x1 = tl.load(x1_ptr + e * H + h, mask=hm, other=0.0)
+    tl.atomic_add(dx_ptr + i * (CHI1 + H) + CHI1 + h, x1 * m, mask=hm)
+
+    # ---- vector message ----
+    xh2 = (tl.load(xh_ptr + j * 3 * H + H + h, mask=hm, other=0.0)
+           * tl.load(rbfh_ptr + e * 3 * H + H + h, mask=hm, other=0.0)) * inv_sqrt_3
+    xh3 = (tl.load(xh_ptr + j * 3 * H + 2 * H + h, mask=hm, other=0.0)
+           * tl.load(rbfh_ptr + e * 3 * H + 2 * H + h, mask=hm, other=0.0))
+    coef = inv_sqrt_h * m
+    for d in range(0, 3):
+        vj = tl.load(vec_ptr + j * 3 * H + d * H + h, mask=hm, other=0.0)
+        rd = tl.load(r_ptr + e * 3 + d)
+        vmsg = (vj * xh2 + xh3 * rd) * coef
+        tl.atomic_add(dvec_ptr + i * 3 * H + d * H + h, vmsg, mask=hm)
+
+
+@triton.jit
+def _bwd_kernel(xh_ptr, vec_ptr, rbfh_ptr, x1_ptr, qr_ptr, qi_ptr, a_ptr,
+                r_ptr, mask_ptr, idx_i_ptr, idx_j_ptr,
+                Kr_ptr, Ki_ptr, u_ptr, v_ptr, fcw_ptr, fcb_ptr,
+                gdx_ptr, gdvec_ptr,
+                gxh_ptr, gvec_ptr, grbfh_ptr, gx1_ptr, gqr_ptr, gqi_ptr,
+                ga_ptr, gr_ptr,
+                H, HCHI, CHI1, CHI2, C, inv_sqrt_3, inv_sqrt_h,
+                HAS_MASK: tl.constexpr,
+                BLOCK_H: tl.constexpr, BLOCK_HCHI: tl.constexpr,
+                BLOCK_C1: tl.constexpr, BLOCK_C2: tl.constexpr):
+    e = tl.program_id(0)
+    i = tl.load(idx_i_ptr + e)
+    j = tl.load(idx_j_ptr + e)
+    if HAS_MASK:
+        m = tl.load(mask_ptr + e)
+    else:
+        m = 1.0
+
+    # ---- recompute forward chi chain ----
+    c2 = tl.arange(0, BLOCK_C2)
+    c2m = c2 < CHI2
+    cc = tl.arange(0, BLOCK_HCHI)
+    ccm = cc < HCHI
+    qr = tl.load(qr_ptr + e * HCHI + cc, mask=ccm, other=0.0)
+    qi = tl.load(qi_ptr + e * HCHI + cc, mask=ccm, other=0.0)
+    kr_bias = tl.zeros([BLOCK_C2], dtype=tl.float32)
+    ki_bias = tl.zeros([BLOCK_C2], dtype=tl.float32)
+    for cidx in range(0, C):
+        kr_bias += tl.load(Kr_ptr + cidx * CHI2 + c2, mask=c2m, other=0.0)
+        ki_bias += tl.load(Ki_ptr + cidx * CHI2 + c2, mask=c2m, other=0.0)
+    Krm = tl.load(Kr_ptr + (C + cc[:, None]) * CHI2 + c2[None, :],
+                  mask=ccm[:, None] & c2m[None, :], other=0.0)
+    Kim = tl.load(Ki_ptr + (C + cc[:, None]) * CHI2 + c2[None, :],
+                  mask=ccm[:, None] & c2m[None, :], other=0.0)
+    conv_r = tl.sum(qr[:, None] * Krm - qi[:, None] * Kim, axis=0) + kr_bias
+    conv_i = tl.sum(qr[:, None] * Kim + qi[:, None] * Krm, axis=0) + ki_bias
+    a = tl.load(a_ptr + e * CHI2 + c2, mask=c2m, other=0.0)
+    ca_r = tl.sum(conv_r * a)
+    ca_i = tl.sum(conv_i * a)
+    cs_r = tl.sum(tl.where(c2m, conv_r, 0.0))
+    cs_i = tl.sum(tl.where(c2m, conv_i, 0.0))
+    c1 = tl.arange(0, BLOCK_C1)
+    c1m = c1 < CHI1
+    u = tl.load(u_ptr + c1, mask=c1m, other=0.0)
+    v = tl.load(v_ptr + c1, mask=c1m, other=0.0)
+    ker_r = ca_r * u + cs_r * v
+    ker_i = ca_i * u + cs_i * v
+    fcw = tl.load(fcw_ptr + c1[:, None] * CHI1 + c1[None, :],
+                  mask=c1m[:, None] & c1m[None, :], other=0.0)
+    fcb = tl.load(fcb_ptr + c1, mask=c1m, other=0.0)
+    fr = tl.sum(fcw * ker_r[None, :], axis=1) + fcb
+    fi = tl.sum(fcw * ker_i[None, :], axis=1) + fcb
+
+    # ---- backward through atan2 -> fc_mps -> rank-1 -> conv -> q ----
+    gk = tl.load(gdx_ptr + i * (CHI1 + H) + c1, mask=c1m, other=0.0) * m
+    denom = fr * fr + fi * fi + 1e-30
+    gfr = -gk * fi / denom
+    gfi = gk * fr / denom
+    # fc_mps^T
+    gker_r = tl.sum(fcw * gfr[:, None], axis=0)
+    gker_i = tl.sum(fcw * gfi[:, None], axis=0)
+    gca_r = tl.sum(gker_r * u)
+    gcs_r = tl.sum(tl.where(c1m, gker_r * v, 0.0))
+    gca_i = tl.sum(gker_i * u)
+    gcs_i = tl.sum(tl.where(c1m, gker_i * v, 0.0))
+    gconv_r = gca_r * a + gcs_r
+    gconv_i = gca_i * a + gcs_i
+    gconv_r = tl.where(c2m, gconv_r, 0.0)
+    gconv_i = tl.where(c2m, gconv_i, 0.0)
+    ga = conv_r * gca_r + conv_i * gca_i
+    tl.store(ga_ptr + e * CHI2 + c2, tl.where(c2m, ga, 0.0), mask=c2m)
+    gqr = tl.sum(Krm * gconv_r[None, :] + Kim * gconv_i[None, :], axis=1)
+    gqi = tl.sum(Krm * gconv_i[None, :] - Kim * gconv_r[None, :], axis=1)
+    tl.store(gqr_ptr + e * HCHI + cc, gqr, mask=ccm)
+    tl.store(gqi_ptr + e * HCHI + cc, gqi, mask=ccm)
+
+    # ---- x1 part of agg ----
+    h = tl.arange(0, BLOCK_H)
+    hm = h < H
+    gx1 = tl.load(gdx_ptr + i * (CHI1 + H) + CHI1 + h, mask=hm, other=0.0) * m
+    tl.store(gx1_ptr + e * H + h, gx1, mask=hm)
+
+    # ---- vector message backward ----
+    rbf2 = tl.load(rbfh_ptr + e * 3 * H + H + h, mask=hm, other=0.0)
+    rbf3 = tl.load(rbfh_ptr + e * 3 * H + 2 * H + h, mask=hm, other=0.0)
+    xhj2 = tl.load(xh_ptr + j * 3 * H + H + h, mask=hm, other=0.0)
+    xhj3 = tl.load(xh_ptr + j * 3 * H + 2 * H + h, mask=hm, other=0.0)
+    xh2 = xhj2 * rbf2 * inv_sqrt_3
+    xh3 = xhj3 * rbf3
+    coef = inv_sqrt_h * m
+    gxh2 = tl.zeros([BLOCK_H], dtype=tl.float32)
+    gxh3 = tl.zeros([BLOCK_H], dtype=tl.float32)
+    for d in range(0, 3):
+        gv = tl.load(gdvec_ptr + i * 3 * H + d * H + h, mask=hm, other=0.0) * coef
+        vj = tl.load(vec_ptr + j * 3 * H + d * H + h, mask=hm, other=0.0)
+        rd = tl.load(r_ptr + e * 3 + d)
+        # d/dvec_j and d/dr accumulate; d/dxh2 += gv*vj; d/dxh3 += gv*rd
+        tl.atomic_add(gvec_ptr + j * 3 * H + d * H + h, gv * xh2, mask=hm)
+        gxh2 += gv * vj
+        gxh3 += gv * rd
+        gr_d = tl.sum(tl.where(hm, gv * xh3, 0.0))
+        tl.atomic_add(gr_ptr + e * 3 + d, gr_d)
+    # chain to xh (blocks 1,2) and rbfh (blocks 1,2); atomic over j for xh
+    tl.atomic_add(gxh_ptr + j * 3 * H + H + h, gxh2 * rbf2 * inv_sqrt_3, mask=hm)
+    tl.atomic_add(gxh_ptr + j * 3 * H + 2 * H + h, gxh3 * rbf3, mask=hm)
+    tl.store(grbfh_ptr + e * 3 * H + H + h, gxh2 * xhj2 * inv_sqrt_3, mask=hm)
+    tl.store(grbfh_ptr + e * 3 * H + 2 * H + h, gxh3 * xhj3, mask=hm)
+
+
+def _pow2(x):
+    return triton.next_power_of_2(max(int(x), 2))
+
+
+class _FusedEquiMessage(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, xh, vec, rbfh, x1, qr, qi, a_dia, r_ij, edge_mask,
+                idx_i, idx_j, Kr, Ki, u, v, fc_w, fc_b, chi1, chi2, head):
+        N, H3 = xh.shape
+        H = H3 // 3
+        E = rbfh.shape[0]
+        HCHI = qr.shape[1]
+        C = HCHI // head
+        dx = torch.zeros(N, chi1 + H, dtype=xh.dtype, device=xh.device)
+        dvec = torch.zeros(N, 3, H, dtype=xh.dtype, device=xh.device)
+        args = dict(H=H, HCHI=HCHI, CHI1=chi1, CHI2=chi2, C=C,
+                    inv_sqrt_3=1.0 / math.sqrt(3.0),
+                    inv_sqrt_h=1.0 / math.sqrt(H),
+                    HAS_MASK=edge_mask is not None,
+                    BLOCK_H=_pow2(H), BLOCK_HCHI=_pow2(HCHI),
+                    BLOCK_C1=_pow2(chi1), BLOCK_C2=_pow2(chi2))
+        mask_arg = edge_mask if edge_mask is not None else rbfh  # dummy ptr
+        if E > 0:
+            _fwd_kernel[(E,)](xh, vec, rbfh, x1, qr, qi, a_dia, r_ij,
+                              mask_arg, idx_i, idx_j, Kr, Ki, u, v, fc_w, fc_b,
+                              dx, dvec, **args)
+        ctx.save_for_backward(xh, vec, rbfh, x1, qr, qi, a_dia, r_ij,
+                              edge_mask if edge_mask is not None else rbfh.new_empty(0),
+                              idx_i, idx_j, Kr, Ki, u, v, fc_w, fc_b)
+        ctx.meta = (H, HCHI, chi1, chi2, C, edge_mask is not None)
+        return dx, dvec
+
+    @staticmethod
+    def backward(ctx, gdx, gdvec):
+        (xh, vec, rbfh, x1, qr, qi, a_dia, r_ij, mask, idx_i, idx_j,
+         Kr, Ki, u, v, fc_w, fc_b) = ctx.saved_tensors
+        H, HCHI, chi1, chi2, C, has_mask = ctx.meta
+        E = rbfh.shape[0]
+        gxh = torch.zeros_like(xh)
+        gvec = torch.zeros_like(vec)
+        grbfh = torch.zeros_like(rbfh)  # blocks 1,2 written; block 0 stays 0
+        gx1 = torch.empty_like(x1)
+        gqr = torch.empty_like(qr)
+        gqi = torch.empty_like(qi)
+        ga = torch.empty_like(a_dia)
+        gr = torch.zeros_like(r_ij)
+        if E > 0:
+            args = dict(H=H, HCHI=HCHI, CHI1=chi1, CHI2=chi2, C=C,
+                        inv_sqrt_3=1.0 / math.sqrt(3.0),
+                        inv_sqrt_h=1.0 / math.sqrt(H),
+                        HAS_MASK=has_mask,
+                        BLOCK_H=_pow2(H), BLOCK_HCHI=_pow2(HCHI),
+                        BLOCK_C1=_pow2(chi1), BLOCK_C2=_pow2(chi2))
+            mask_arg = mask if has_mask else rbfh
+            _bwd_kernel[(E,)](xh, vec, rbfh, x1, qr, qi, a_dia, r_ij,
+                              mask_arg, idx_i, idx_j, Kr, Ki, u, v, fc_w, fc_b,
+                              gdx.contiguous(), gdvec.contiguous(),
+                              gxh, gvec, grbfh, gx1, gqr, gqi, ga, gr, **args)
+        else:
+            gx1.zero_(); gqr.zero_(); gqi.zero_(); ga.zero_()
+        return (gxh, gvec, grbfh, gx1, gqr, gqi, ga, gr,
+                None, None, None, None, None, None, None, None, None,
+                None, None, None)
+
+
+def fused_equi_message(layer, xh, vec, rbfh, edge_vector, edge_index,
+                       edge_mask):
+    """Fused replacement for EquiMessagePassing.propagate (inference, fp32).
+
+    ``layer`` is the EquiMessagePassing module; the scale GEMM and the
+    diagonal MLP run in cuBLAS/torch here (autograd handles their weights'
+    chain), the rest of the message + aggregation is one Triton kernel.
+    Returns (dx, dvec) with dx already [N, chi1+H] as the reference
+    scatter produces.
+    """
+    assert layer.reduce_mode == "sum", "fused message requires sum reduction"
+    j, i = edge_index[0], edge_index[1]
+    H = layer.hidden_channels
+    x1 = xh.index_select(0, j)[:, :H] * rbfh[:, :H]
+    qr, qi = torch.split(layer.scale(x1), layer.hidden_channels_chi, dim=-1)
+    a_dia = layer.activation(layer.diagonal(rbfh))
+    norm_factor = math.sqrt(H // layer.head)
+    Kr = (layer.kernel_real / norm_factor).reshape(-1, layer.chi2)
+    Ki = (layer.kernel_imag / norm_factor).reshape(-1, layer.chi2)
+    u = torch.matmul(layer.dia.weight, layer.diachi1)
+    v = layer.dia.weight.sum(1) + layer.dia.bias
+    mask_flat = edge_mask.reshape(-1).contiguous() if edge_mask is not None else None
+    return _FusedEquiMessage.apply(
+        xh.contiguous(), vec.contiguous(),
+        rbfh.contiguous(), x1.contiguous(), qr.contiguous(), qi.contiguous(),
+        a_dia.contiguous(), edge_vector.contiguous(), mask_flat,
+        i.contiguous(), j.contiguous(),
+        Kr.contiguous(), Ki.contiguous(), u.contiguous(), v.contiguous(),
+        layer.fc_mps.weight.contiguous(), layer.fc_mps.bias.contiguous(),
+        layer.chi1, layer.chi2, layer.head)

--- a/alphanet/ops/scalarization.py
+++ b/alphanet/ops/scalarization.py
@@ -1,0 +1,234 @@
+"""Fused edge-frame scalarization + per-channel MLP (plan phase-3 operator B).
+
+Reference computation (alphanet.py forward):
+    p[e,f,h]   = sum_d edge_frame[e,d,f] * S[src[e],d,h]      (src = i or j)
+    t          = (p0, p1^2, p2)
+    scalar[e,h]= ( w2 . silu(W1 @ t + b1) + b2 + p0 ) / sqrt(H)
+
+The reference materializes two [E,3,H] projections and, worse, two
+[E,H,H/4] MLP hidden blocks that autograd keeps for backward — the largest
+single allocation in the model. Here every intermediate lives in registers;
+the backward recomputes them and emits grad_S (atomic scatter over nodes)
+and grad_frame only. Weight gradients are intentionally not implemented:
+the fused path is inference-only (training uses the reference path).
+
+fp32 + CUDA only; the caller falls back to the reference otherwise.
+"""
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _silu(x):
+    return x * tl.sigmoid(x)
+
+
+@triton.jit
+def _project(f0, f1, f2, f3, f4, f5, f6, f7, f8, s0, s1, s2):
+    # p_f = sum_d frame[d,f] * S[d]; frame row-major [d,f]
+    p0 = f0 * s0 + f3 * s1 + f6 * s2
+    p1 = f1 * s0 + f4 * s1 + f7 * s2
+    p2 = f2 * s0 + f5 * s1 + f8 * s2
+    return p0, p1, p2
+
+
+@triton.jit
+def _mlp_out(p0, p1, p2, W1_ptr, b1_ptr, w2_ptr, b2_ptr, HQ, BLOCK_Q: tl.constexpr):
+    # hidden[q,h] = silu(W1[q,0]*p0 + W1[q,1]*p1^2 + W1[q,2]*p2 + b1[q])
+    q = tl.arange(0, BLOCK_Q)
+    qm = q < HQ
+    w1a = tl.load(W1_ptr + q * 3 + 0, mask=qm, other=0.0)
+    w1b = tl.load(W1_ptr + q * 3 + 1, mask=qm, other=0.0)
+    w1c = tl.load(W1_ptr + q * 3 + 2, mask=qm, other=0.0)
+    b1 = tl.load(b1_ptr + q, mask=qm, other=0.0)
+    w2 = tl.load(w2_ptr + q, mask=qm, other=0.0)
+    t1 = p1 * p1
+    pre = (w1a[:, None] * p0[None, :] + w1b[:, None] * t1[None, :]
+           + w1c[:, None] * p2[None, :] + b1[:, None])
+    hid = tl.where(qm[:, None], _silu(pre), 0.0)
+    return tl.sum(hid * w2[:, None], axis=0) + tl.load(b2_ptr)
+
+
+@triton.jit
+def _fwd_kernel(S_ptr, frame_ptr, idx_i_ptr, idx_j_ptr,
+                W1_ptr, b1_ptr, w2_ptr, b2_ptr, scale,
+                out3_ptr, out4_ptr, H, HQ,
+                BLOCK_H: tl.constexpr, BLOCK_Q: tl.constexpr):
+    e = tl.program_id(0)
+    h = tl.program_id(1) * BLOCK_H + tl.arange(0, BLOCK_H)
+    hm = h < H
+    fbase = frame_ptr + e * 9
+    f0 = tl.load(fbase + 0); f1 = tl.load(fbase + 1); f2 = tl.load(fbase + 2)
+    f3 = tl.load(fbase + 3); f4 = tl.load(fbase + 4); f5 = tl.load(fbase + 5)
+    f6 = tl.load(fbase + 6); f7 = tl.load(fbase + 7); f8 = tl.load(fbase + 8)
+
+    i = tl.load(idx_i_ptr + e)
+    s0 = tl.load(S_ptr + i * 3 * H + 0 * H + h, mask=hm, other=0.0)
+    s1 = tl.load(S_ptr + i * 3 * H + 1 * H + h, mask=hm, other=0.0)
+    s2 = tl.load(S_ptr + i * 3 * H + 2 * H + h, mask=hm, other=0.0)
+    p0, p1, p2 = _project(f0, f1, f2, f3, f4, f5, f6, f7, f8, s0, s1, s2)
+    out = _mlp_out(p0, p1, p2, W1_ptr, b1_ptr, w2_ptr, b2_ptr, HQ, BLOCK_Q)
+    tl.store(out3_ptr + e * H + h, (out + p0) * scale, mask=hm)
+
+    j = tl.load(idx_j_ptr + e)
+    s0 = tl.load(S_ptr + j * 3 * H + 0 * H + h, mask=hm, other=0.0)
+    s1 = tl.load(S_ptr + j * 3 * H + 1 * H + h, mask=hm, other=0.0)
+    s2 = tl.load(S_ptr + j * 3 * H + 2 * H + h, mask=hm, other=0.0)
+    p0, p1, p2 = _project(f0, f1, f2, f3, f4, f5, f6, f7, f8, s0, s1, s2)
+    out = _mlp_out(p0, p1, p2, W1_ptr, b1_ptr, w2_ptr, b2_ptr, HQ, BLOCK_Q)
+    tl.store(out4_ptr + e * H + h, (out + p0) * scale, mask=hm)
+
+
+@triton.jit
+def _bwd_dp(p0, p1, p2, g, W1_ptr, b1_ptr, w2_ptr, scale, HQ, BLOCK_Q: tl.constexpr):
+    # recompute hidden, return dL/dp0, dL/dp1, dL/dp2 for one source
+    q = tl.arange(0, BLOCK_Q)
+    qm = q < HQ
+    w1a = tl.load(W1_ptr + q * 3 + 0, mask=qm, other=0.0)
+    w1b = tl.load(W1_ptr + q * 3 + 1, mask=qm, other=0.0)
+    w1c = tl.load(W1_ptr + q * 3 + 2, mask=qm, other=0.0)
+    b1 = tl.load(b1_ptr + q, mask=qm, other=0.0)
+    w2 = tl.load(w2_ptr + q, mask=qm, other=0.0)
+    t1 = p1 * p1
+    pre = (w1a[:, None] * p0[None, :] + w1b[:, None] * t1[None, :]
+           + w1c[:, None] * p2[None, :] + b1[:, None])
+    sig = tl.sigmoid(pre)
+    dsilu = sig * (1.0 + pre * (1.0 - sig))
+    dout = g * scale                                   # [BLOCK_H]
+    dpre = tl.where(qm[:, None], dsilu * (w2[:, None] * dout[None, :]), 0.0)
+    dp0 = tl.sum(dpre * w1a[:, None], axis=0) + dout   # +dout: the "+p0" term
+    dp1 = tl.sum(dpre * w1b[:, None], axis=0) * 2.0 * p1
+    dp2 = tl.sum(dpre * w1c[:, None], axis=0)
+    return dp0, dp1, dp2
+
+
+@triton.jit
+def _bwd_kernel(S_ptr, frame_ptr, idx_i_ptr, idx_j_ptr,
+                W1_ptr, b1_ptr, w2_ptr, scale,
+                g3_ptr, g4_ptr, gS_ptr, gframe_ptr, H, HQ,
+                BLOCK_H: tl.constexpr, BLOCK_Q: tl.constexpr):
+    e = tl.program_id(0)
+    h = tl.program_id(1) * BLOCK_H + tl.arange(0, BLOCK_H)
+    hm = h < H
+    fbase = frame_ptr + e * 9
+    f0 = tl.load(fbase + 0); f1 = tl.load(fbase + 1); f2 = tl.load(fbase + 2)
+    f3 = tl.load(fbase + 3); f4 = tl.load(fbase + 4); f5 = tl.load(fbase + 5)
+    f6 = tl.load(fbase + 6); f7 = tl.load(fbase + 7); f8 = tl.load(fbase + 8)
+
+    gf0 = 0.0; gf1 = 0.0; gf2 = 0.0; gf3 = 0.0; gf4 = 0.0
+    gf5 = 0.0; gf6 = 0.0; gf7 = 0.0; gf8 = 0.0
+
+    # ---- source i (scalar3) ----
+    i = tl.load(idx_i_ptr + e)
+    s0 = tl.load(S_ptr + i * 3 * H + 0 * H + h, mask=hm, other=0.0)
+    s1 = tl.load(S_ptr + i * 3 * H + 1 * H + h, mask=hm, other=0.0)
+    s2 = tl.load(S_ptr + i * 3 * H + 2 * H + h, mask=hm, other=0.0)
+    p0, p1, p2 = _project(f0, f1, f2, f3, f4, f5, f6, f7, f8, s0, s1, s2)
+    g = tl.load(g3_ptr + e * H + h, mask=hm, other=0.0)
+    dp0, dp1, dp2 = _bwd_dp(p0, p1, p2, g, W1_ptr, b1_ptr, w2_ptr, scale, HQ, BLOCK_Q)
+    tl.atomic_add(gS_ptr + i * 3 * H + 0 * H + h, f0 * dp0 + f1 * dp1 + f2 * dp2, mask=hm)
+    tl.atomic_add(gS_ptr + i * 3 * H + 1 * H + h, f3 * dp0 + f4 * dp1 + f5 * dp2, mask=hm)
+    tl.atomic_add(gS_ptr + i * 3 * H + 2 * H + h, f6 * dp0 + f7 * dp1 + f8 * dp2, mask=hm)
+    gf0 += tl.sum(tl.where(hm, s0 * dp0, 0.0)); gf1 += tl.sum(tl.where(hm, s0 * dp1, 0.0)); gf2 += tl.sum(tl.where(hm, s0 * dp2, 0.0))
+    gf3 += tl.sum(tl.where(hm, s1 * dp0, 0.0)); gf4 += tl.sum(tl.where(hm, s1 * dp1, 0.0)); gf5 += tl.sum(tl.where(hm, s1 * dp2, 0.0))
+    gf6 += tl.sum(tl.where(hm, s2 * dp0, 0.0)); gf7 += tl.sum(tl.where(hm, s2 * dp1, 0.0)); gf8 += tl.sum(tl.where(hm, s2 * dp2, 0.0))
+
+    # ---- source j (scalar4) ----
+    j = tl.load(idx_j_ptr + e)
+    s0 = tl.load(S_ptr + j * 3 * H + 0 * H + h, mask=hm, other=0.0)
+    s1 = tl.load(S_ptr + j * 3 * H + 1 * H + h, mask=hm, other=0.0)
+    s2 = tl.load(S_ptr + j * 3 * H + 2 * H + h, mask=hm, other=0.0)
+    p0, p1, p2 = _project(f0, f1, f2, f3, f4, f5, f6, f7, f8, s0, s1, s2)
+    g = tl.load(g4_ptr + e * H + h, mask=hm, other=0.0)
+    dp0, dp1, dp2 = _bwd_dp(p0, p1, p2, g, W1_ptr, b1_ptr, w2_ptr, scale, HQ, BLOCK_Q)
+    tl.atomic_add(gS_ptr + j * 3 * H + 0 * H + h, f0 * dp0 + f1 * dp1 + f2 * dp2, mask=hm)
+    tl.atomic_add(gS_ptr + j * 3 * H + 1 * H + h, f3 * dp0 + f4 * dp1 + f5 * dp2, mask=hm)
+    tl.atomic_add(gS_ptr + j * 3 * H + 2 * H + h, f6 * dp0 + f7 * dp1 + f8 * dp2, mask=hm)
+    gf0 += tl.sum(tl.where(hm, s0 * dp0, 0.0)); gf1 += tl.sum(tl.where(hm, s0 * dp1, 0.0)); gf2 += tl.sum(tl.where(hm, s0 * dp2, 0.0))
+    gf3 += tl.sum(tl.where(hm, s1 * dp0, 0.0)); gf4 += tl.sum(tl.where(hm, s1 * dp1, 0.0)); gf5 += tl.sum(tl.where(hm, s1 * dp2, 0.0))
+    gf6 += tl.sum(tl.where(hm, s2 * dp0, 0.0)); gf7 += tl.sum(tl.where(hm, s2 * dp1, 0.0)); gf8 += tl.sum(tl.where(hm, s2 * dp2, 0.0))
+
+    gbase = gframe_ptr + e * 9
+    tl.atomic_add(gbase + 0, gf0); tl.atomic_add(gbase + 1, gf1); tl.atomic_add(gbase + 2, gf2)
+    tl.atomic_add(gbase + 3, gf3); tl.atomic_add(gbase + 4, gf4); tl.atomic_add(gbase + 5, gf5)
+    tl.atomic_add(gbase + 6, gf6); tl.atomic_add(gbase + 7, gf7); tl.atomic_add(gbase + 8, gf8)
+
+
+_WARNED_WEIGHT_GRAD = False
+
+
+def _blocks(H, HQ):
+    BLOCK_H = 64 if H > 64 else triton.next_power_of_2(max(H, 16))
+    BLOCK_Q = triton.next_power_of_2(max(HQ, 16))
+    return BLOCK_H, BLOCK_Q
+
+
+class _FusedScalarizationMLP(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, S, frame, idx_i, idx_j, W1, b1, w2, b2, scale):
+        E = frame.shape[0]
+        H = S.shape[2]
+        HQ = W1.shape[0]
+        out3 = torch.empty(E, H, dtype=S.dtype, device=S.device)
+        out4 = torch.empty(E, H, dtype=S.dtype, device=S.device)
+        if E > 0:
+            BLOCK_H, BLOCK_Q = _blocks(H, HQ)
+            grid = (E, triton.cdiv(H, BLOCK_H))
+            _fwd_kernel[grid](S, frame, idx_i, idx_j, W1, b1, w2,
+                              b2, float(scale), out3, out4, H, HQ,
+                              BLOCK_H=BLOCK_H, BLOCK_Q=BLOCK_Q)
+        ctx.save_for_backward(S, frame, idx_i, idx_j, W1, b1, w2)
+        ctx.scale = float(scale)
+        return out3, out4
+
+    @staticmethod
+    def backward(ctx, g3, g4):
+        if any(ctx.needs_input_grad[4:8]):
+            # Inference calls autograd.grad(energy, positions): the engine may
+            # still flag the (requires_grad) weights here even though their
+            # gradients are pruned from the requested outputs. Returning None
+            # is correct for that use. Actual training must not run through
+            # the fused path (the model gates it on `not self.training`).
+            global _WARNED_WEIGHT_GRAD
+            if not _WARNED_WEIGHT_GRAD:
+                import warnings
+                warnings.warn(
+                    "fused scalarization does not produce weight gradients; "
+                    "train with use_fused_ops disabled")
+                _WARNED_WEIGHT_GRAD = True
+        S, frame, idx_i, idx_j, W1, b1, w2 = ctx.saved_tensors
+        E = frame.shape[0]
+        H = S.shape[2]
+        HQ = W1.shape[0]
+        gS = torch.zeros_like(S)
+        gframe = torch.zeros_like(frame)
+        if E > 0:
+            BLOCK_H, BLOCK_Q = _blocks(H, HQ)
+            grid = (E, triton.cdiv(H, BLOCK_H))
+            _bwd_kernel[grid](S, frame, idx_i, idx_j, W1, b1, w2,
+                              ctx.scale, g3.contiguous(), g4.contiguous(),
+                              gS, gframe, H, HQ,
+                              BLOCK_H=BLOCK_H, BLOCK_Q=BLOCK_Q)
+        return gS, gframe, None, None, None, None, None, None, None
+
+
+def fused_scalarization_mlp(S, edge_frame, idx_i, idx_j, lin, hidden_channels):
+    """Drop-in fused replacement for the scalarization + lin MLP block.
+
+    Args mirror the reference code: ``S`` is S_i_j [N,3,H], ``edge_frame``
+    [E,3,3], ``idx_i``/``idx_j`` the edge target/source rows, ``lin`` the
+    Sequential(Linear(3,H//4), SiLU, Linear(H//4,1)) module. Returns
+    (scalar3, scalar4), each [E,H], already divided by sqrt(H).
+    """
+    W1 = lin[0].weight.contiguous()
+    b1 = lin[0].bias.contiguous()
+    w2 = lin[2].weight.reshape(-1).contiguous()
+    b2 = (lin[2].bias.contiguous() if lin[2].bias is not None
+          else torch.zeros(1, dtype=S.dtype, device=S.device))
+    scale = 1.0 / math.sqrt(hidden_channels)
+    return _FusedScalarizationMLP.apply(
+        S.contiguous(), edge_frame.contiguous(),
+        idx_i.contiguous(), idx_j.contiguous(), W1, b1, w2, b2, scale)


### PR DESCRIPTION
Rewrite complex-valued MPS contractions as equivalent real arithmetic, add whole-step CUDA graph capture with automatic path selection, cache neighbor topology for the stress path, and fuse hot per-edge operations into Triton kernels with fallback to the reference path.